### PR TITLE
feat: allow user to set additionalProperties or requiredProperties on oas response schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ Included in this repository is a [sample Pact file](./docs/pact.json)
 Default behaviour, as per the following flags 
 
 - `--additionalPropertiesInResponse` true
-- `--additionalPropertiesInResponse` false
+- `--requiredPropertiesInResponse` false
 
-`❯ ./bin/swagger-mock-validator-local https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
+`npx @pactflow/swagger-mock-validator https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
 
 ```bash
 0 error(s)
@@ -154,7 +154,9 @@ Default behaviour, as per the following flags
 With 
 
 - `--additionalPropertiesInResponse` false
-- `--additionalPropertiesInResponse` false
+- `--requiredPropertiesInResponse` false
+
+``npx @pactflow/swagger-mock-validator --additionalPropertiesInResponse false --requiredPropertiesInResponse false https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
 
 ```bash
 Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"
@@ -193,9 +195,9 @@ Error: Mock file "./docs/pact.json" is not compatible with spec file "https://pe
 With 
 
 - `--additionalPropertiesInResponse` false
-- `--additionalPropertiesInResponse` true
+- `--requiredPropertiesInResponse` true
 
-`❯ ./bin/swagger-mock-validator-local --additionalPropertiesInResponse false --requiredPropertiesInResponse true https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
+`npx @pactflow/swagger-mock-validator --additionalPropertiesInResponse false --requiredPropertiesInResponse true https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
 
 ```bash
 
@@ -275,9 +277,9 @@ Error: Mock file "./docs/pact.json" is not compatible with spec file "https://pe
 With 
 
 - `--additionalPropertiesInResponse` true
-- `--additionalPropertiesInResponse` true
+- `--requiredPropertiesInResponse` true
 
-`❯ ./bin/swagger-mock-validator-local --additionalPropertiesInResponse false --requiredPropertiesInResponse true https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
+`npx @pactflow/swagger-mock-validator --additionalPropertiesInResponse false --requiredPropertiesInResponse true https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
 
 ```bash
 Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ With
 - `--additionalPropertiesInResponse` false
 - `--requiredPropertiesInResponse` false
 
-``npx @pactflow/swagger-mock-validator --additionalPropertiesInResponse false --requiredPropertiesInResponse false https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
+`npx @pactflow/swagger-mock-validator --additionalPropertiesInResponse false --requiredPropertiesInResponse false https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
 
 ```bash
 Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"

--- a/README.md
+++ b/README.md
@@ -53,10 +53,285 @@ swagger-mock-validator spec.json mock.json --outputDepth 5
 ```
 
 For more options on how to use the command run the command with the help flag.
-```
-swagger-mock-validator --help
+
+`swagger-mock-validator --help`
+
+```bash
+Usage: swagger-mock-validator-local [options] <swagger> <mock>
+
+Confirms the swagger spec and mock are compatible with each other.
+
+Basic Usage:
+The <swagger> and <mock> arguments should paths to the json files or urls to the json files.
+
+Supported Mock Formats:
+Pact
+
+Pact Broker:
+For providers using the pact broker the <mock> argument should be the url to the root of the
+pact broker and the provider name should be passed using the --provider option. This will
+automatically find the latest versions of the consumer pact file(s) uploaded to the broker for
+the specified provider name. The <swagger> argument should be the path or url to the swagger
+json file. Optionally, pass a --tag option alongside a --provider option to filter the retrieved
+pacts from the broker by Pact Broker version tags.
+
+If the pact broker has basic auth enabled, pass a --user option with username and password joined by a colon
+(i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.
+
+Options:
+  -V, --version                                   output the version number
+  -p, --provider [string]                         The name of the provider in the pact broker
+  -t, --tag [string]                              The tag to filter pacts retrieved from the pact broker
+  -u, --user [USERNAME:PASSWORD]                  The basic auth username and password to access the pact broker
+  -a, --analyticsUrl [string]                     The url to send analytics events to as a http post
+  -o, --outputDepth [integer]                     Specifies the number of times to recurse while formatting the output objects. This is useful in case of large complicated objects or schemas. (default: 4)
+  -A, --additionalPropertiesInResponse [boolean]  set additionalProperties response body to defined value, defaults true
+  -R, --requiredPropertiesInResponse [boolean]    set additionalProperties response body to required value, default true
+  -h, --help                                      display help for command
 ```
 
+
+## Examples
+
+We will demonstate with a sample Pact file and [Swagger PetStore Example](https://petstore.swagger.io/v2/swagger.json)
+
+Included in this repository is a [sample Pact file](./docs/pact.json)
+
+```json
+{
+  "consumer": {
+    "name": "MyConsumer"
+  },
+  "provider": {
+    "name": "pactWith"
+  },
+  "interactions": [
+    {
+      "description": "A get request to get a pet 1845563262948980200",
+      "providerState": "A pet 1845563262948980200 exists",
+      "request": {
+        "method": "GET",
+        "path": "/v2/pet/1845563262948980200",
+        "headers": {
+          "api_key": "[]"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "someField": "some string"
+        },
+        "matchingRules": {
+          "$.body.someField": {
+            "match": "type"
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    }
+  }
+}
+```
+
+Default behaviour, as per the following flags 
+
+- `--additionalPropertiesInResponse` true
+- `--additionalPropertiesInResponse` false
+
+`❯ ./bin/swagger-mock-validator-local https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
+
+```bash
+0 error(s)
+0 warning(s)
+```
+
+With 
+
+- `--additionalPropertiesInResponse` false
+- `--additionalPropertiesInResponse` false
+
+```bash
+Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"
+1 error(s)
+        response.body.incompatible: 1
+0 warning(s)
+{
+  warnings: [],
+  errors: [
+    {
+      code: 'response.body.incompatible',
+      message: 'Response body is incompatible with the response body schema in the spec file: should NOT have additional properties - someField',
+      mockDetails: {
+        interactionDescription: 'A get request to get a pet 1845563262948980200',
+        interactionState: 'A pet 1845563262948980200 exists',
+        location: '[root].interactions[0].response.body',
+        mockFile: './docs/pact.json',
+        value: { someField: 'some string' }
+      },
+      source: 'spec-mock-validation',
+      specDetails: {
+        location: '[root].paths./pet/{petId}.get.responses.200.schema.additionalProperties',
+        pathMethod: 'get',
+        pathName: '/pet/{petId}',
+        specFile: 'https://petstore.swagger.io/v2/swagger.json',
+        value: undefined
+      },
+      type: 'error'
+    }
+  ]
+}
+
+Error: Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"
+```
+
+With 
+
+- `--additionalPropertiesInResponse` false
+- `--additionalPropertiesInResponse` true
+
+`❯ ./bin/swagger-mock-validator-local --additionalPropertiesInResponse false --requiredPropertiesInResponse true https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
+
+```bash
+
+Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"
+3 error(s)
+        response.body.incompatible: 3
+0 warning(s)
+{
+  warnings: [],
+  errors: [
+    {
+      code: 'response.body.incompatible',
+      message: 'Response body is incompatible with the response body schema in the spec file: should NOT have additional properties - someField',
+      mockDetails: {
+        interactionDescription: 'A get request to get a pet 1845563262948980200',
+        interactionState: 'A pet 1845563262948980200 exists',
+        location: '[root].interactions[0].response.body',
+        mockFile: './docs/pact.json',
+        value: { someField: 'some string' }
+      },
+      source: 'spec-mock-validation',
+      specDetails: {
+        location: '[root].paths./pet/{petId}.get.responses.200.schema.additionalProperties',
+        pathMethod: 'get',
+        pathName: '/pet/{petId}',
+        specFile: 'https://petstore.swagger.io/v2/swagger.json',
+        value: undefined
+      },
+      type: 'error'
+    },
+    {
+      code: 'response.body.incompatible',
+      message: "Response body is incompatible with the response body schema in the spec file: should have required property 'name'",
+      mockDetails: {
+        interactionDescription: 'A get request to get a pet 1845563262948980200',
+        interactionState: 'A pet 1845563262948980200 exists',
+        location: '[root].interactions[0].response.body',
+        mockFile: './docs/pact.json',
+        value: { someField: 'some string' }
+      },
+      source: 'spec-mock-validation',
+      specDetails: {
+        location: '[root].paths./pet/{petId}.get.responses.200.schema.required',
+        pathMethod: 'get',
+        pathName: '/pet/{petId}',
+        specFile: 'https://petstore.swagger.io/v2/swagger.json',
+        value: [ 'name', 'photoUrls' ]
+      },
+      type: 'error'
+    },
+    {
+      code: 'response.body.incompatible',
+      message: "Response body is incompatible with the response body schema in the spec file: should have required property 'photoUrls'",
+      mockDetails: {
+        interactionDescription: 'A get request to get a pet 1845563262948980200',
+        interactionState: 'A pet 1845563262948980200 exists',
+        location: '[root].interactions[0].response.body',
+        mockFile: './docs/pact.json',
+        value: { someField: 'some string' }
+      },
+      source: 'spec-mock-validation',
+      specDetails: {
+        location: '[root].paths./pet/{petId}.get.responses.200.schema.required',
+        pathMethod: 'get',
+        pathName: '/pet/{petId}',
+        specFile: 'https://petstore.swagger.io/v2/swagger.json',
+        value: [ 'name', 'photoUrls' ]
+      },
+      type: 'error'
+    }
+  ]
+}
+
+Error: Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"
+```
+
+With 
+
+- `--additionalPropertiesInResponse` true
+- `--additionalPropertiesInResponse` true
+
+`❯ ./bin/swagger-mock-validator-local --additionalPropertiesInResponse false --requiredPropertiesInResponse true https://petstore.swagger.io/v2/swagger.json ./docs/pact.json`
+
+```bash
+Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"
+2 error(s)
+        response.body.incompatible: 2
+0 warning(s)
+{
+  warnings: [],
+  errors: [
+    {
+      code: 'response.body.incompatible',
+      message: "Response body is incompatible with the response body schema in the spec file: should have required property 'name'",
+      mockDetails: {
+        interactionDescription: 'A get request to get a pet 1845563262948980200',
+        interactionState: 'A pet 1845563262948980200 exists',
+        location: '[root].interactions[0].response.body',
+        mockFile: './docs/pact.json',
+        value: { someField: 'some string' }
+      },
+      source: 'spec-mock-validation',
+      specDetails: {
+        location: '[root].paths./pet/{petId}.get.responses.200.schema.required',
+        pathMethod: 'get',
+        pathName: '/pet/{petId}',
+        specFile: 'https://petstore.swagger.io/v2/swagger.json',
+        value: [ 'name', 'photoUrls' ]
+      },
+      type: 'error'
+    },
+    {
+      code: 'response.body.incompatible',
+      message: "Response body is incompatible with the response body schema in the spec file: should have required property 'photoUrls'",
+      mockDetails: {
+        interactionDescription: 'A get request to get a pet 1845563262948980200',
+        interactionState: 'A pet 1845563262948980200 exists',
+        location: '[root].interactions[0].response.body',
+        mockFile: './docs/pact.json',
+        value: { someField: 'some string' }
+      },
+      source: 'spec-mock-validation',
+      specDetails: {
+        location: '[root].paths./pet/{petId}.get.responses.200.schema.required',
+        pathMethod: 'get',
+        pathName: '/pet/{petId}',
+        specFile: 'https://petstore.swagger.io/v2/swagger.json',
+        value: [ 'name', 'photoUrls' ]
+      },
+      type: 'error'
+    }
+  ]
+}
+
+Error: Mock file "./docs/pact.json" is not compatible with spec file "https://petstore.swagger.io/v2/swagger.json"
+```
 ### Providers using the Pact Broker
 
 Provider services can easily verify all the consumer pact files uploaded to a Pact Broker using this tool. Invoke the tool with a url to the Pact Broker along with the name of the provider service and the tool will automatically discover and validate the latest versions of the consumer pact files for the provider service.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For more options on how to use the command run the command with the help flag.
 `swagger-mock-validator --help`
 
 ```bash
-Usage: swagger-mock-validator-local [options] <swagger> <mock>
+Usage: swagger-mock-validator [options] <swagger> <mock>
 
 Confirms the swagger spec and mock are compatible with each other.
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Options:
   -u, --user [USERNAME:PASSWORD]                  The basic auth username and password to access the pact broker
   -a, --analyticsUrl [string]                     The url to send analytics events to as a http post
   -o, --outputDepth [integer]                     Specifies the number of times to recurse while formatting the output objects. This is useful in case of large complicated objects or schemas. (default: 4)
-  -A, --additionalPropertiesInResponse [boolean]  set additionalProperties response body to defined value, defaults true
-  -R, --requiredPropertiesInResponse [boolean]    set additionalProperties response body to required value, default true
+  -A, --additionalPropertiesInResponse [boolean]  allow additional properties in response bodies, default true
+  -R, --requiredPropertiesInResponse [boolean]    allows required properties in response bodies, default false
   -h, --help                                      display help for command
 ```
 

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -52,6 +52,8 @@ commander
     .option('-o, --outputDepth [integer]', 'Specifies the number of times to recurse ' +
     'while formatting the output objects. ' +
     'This is useful in case of large complicated objects or schemas.', parseInt, 4)
+    .option('-A, --additionalPropertiesInResponse [boolean]', 'set additionalProperties response body to defined value, defaults true')
+    .option('-R, --requiredPropertiesInResponse [boolean]', 'set additionalProperties response body to required value, default true')
     .description(`Confirms the swagger spec and mock are compatible with each other.
 
 Basic Usage:
@@ -78,7 +80,9 @@ If the pact broker has basic auth enabled, pass a --user option with username an
             mockPathOrUrl: mock,
             providerName: options.provider,
             specPathOrUrl: swagger,
-            tag: options.tag
+            tag: options.tag,
+            additionalPropertiesInResponse: options.additionalPropertiesInResponse,
+            requiredPropertiesInResponse: options.requiredPropertiesInResponse
         });
         displaySummary(result, options.outputDepth);
         if (!result.success) {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -52,8 +52,8 @@ commander
     .option('-o, --outputDepth [integer]', 'Specifies the number of times to recurse ' +
     'while formatting the output objects. ' +
     'This is useful in case of large complicated objects or schemas.', parseInt, 4)
-    .option('-A, --additionalPropertiesInResponse [boolean]', 'set additionalProperties response body to defined value, defaults true')
-    .option('-R, --requiredPropertiesInResponse [boolean]', 'set additionalProperties response body to required value, default true')
+    .option('-A, --additionalPropertiesInResponse [boolean]', 'allow additional properties in response bodies, default true')
+    .option('-R, --requiredPropertiesInResponse [boolean]', 'allows required properties in response bodies, default false')
     .description(`Confirms the swagger spec and mock are compatible with each other.
 
 Basic Usage:

--- a/dist/swagger-mock-validator/validate-spec-and-mock.js
+++ b/dist/swagger-mock-validator/validate-spec-and-mock.js
@@ -15,19 +15,19 @@ const validate_parsed_spec_consumes_1 = require("./validate-spec-and-mock/valida
 const validate_parsed_spec_produces_1 = require("./validate-spec-and-mock/validate-parsed-spec-produces");
 const validate_parsed_spec_security_1 = require("./validate-spec-and-mock/validate-parsed-spec-security");
 const validateMockInteractionRequest = (parsedMockInteraction, parsedSpecOperation) => _.concat((0, validate_parsed_spec_consumes_1.validateParsedSpecConsumes)(parsedMockInteraction, parsedSpecOperation), (0, validate_parsed_spec_produces_1.validateParsedSpecProduces)(parsedMockInteraction, parsedSpecOperation), (0, validate_parsed_spec_security_1.validateParsedSpecSecurity)(parsedMockInteraction, parsedSpecOperation), (0, validate_parsed_mock_request_body_1.validateParsedMockRequestBody)(parsedMockInteraction, parsedSpecOperation), (0, validate_parsed_mock_request_headers_1.validateParsedMockRequestHeaders)(parsedMockInteraction, parsedSpecOperation), (0, validate_parsed_mock_request_query_1.validateParsedMockRequestQuery)(parsedMockInteraction, parsedSpecOperation));
-const validateMockInteractionResponse = (parsedMockInteraction, parsedSpecOperation) => {
+const validateMockInteractionResponse = (parsedMockInteraction, parsedSpecOperation, opts) => {
     const parsedSpecResponseResult = (0, get_parsed_spec_response_1.getParsedSpecResponse)(parsedMockInteraction, parsedSpecOperation);
     if (!parsedSpecResponseResult.found) {
         return parsedSpecResponseResult.results;
     }
-    return _.concat(parsedSpecResponseResult.results, (0, validate_parsed_mock_response_body_1.validateParsedMockResponseBody)(parsedMockInteraction, parsedSpecResponseResult.value), (0, validate_parsed_mock_response_headers_1.validateParsedMockResponseHeaders)(parsedMockInteraction, parsedSpecResponseResult.value));
+    return _.concat(parsedSpecResponseResult.results, (0, validate_parsed_mock_response_body_1.validateParsedMockResponseBody)(parsedMockInteraction, parsedSpecResponseResult.value, opts), (0, validate_parsed_mock_response_headers_1.validateParsedMockResponseHeaders)(parsedMockInteraction, parsedSpecResponseResult.value));
 };
-const validateMockInteraction = (parsedMockInteraction, normalizedParsedSpec) => {
+const validateMockInteraction = (parsedMockInteraction, normalizedParsedSpec, opts) => {
     const getParsedSpecOperationResult = (0, get_parsed_spec_operation_1.getParsedSpecOperation)(parsedMockInteraction, normalizedParsedSpec);
     if (!getParsedSpecOperationResult.found) {
         return getParsedSpecOperationResult.results;
     }
-    return _.concat(getParsedSpecOperationResult.results, validateMockInteractionRequest(parsedMockInteraction, getParsedSpecOperationResult.value), validateMockInteractionResponse(parsedMockInteraction, getParsedSpecOperationResult.value));
+    return _.concat(getParsedSpecOperationResult.results, validateMockInteractionRequest(parsedMockInteraction, getParsedSpecOperationResult.value), validateMockInteractionResponse(parsedMockInteraction, getParsedSpecOperationResult.value, opts));
 };
 const createValidationOutcome = (validationResults, mockPathOrUrl, specPathOrUrl) => {
     const errors = _.filter(validationResults, (res) => res.type === 'error');
@@ -38,11 +38,11 @@ const createValidationOutcome = (validationResults, mockPathOrUrl, specPathOrUrl
         : `Mock file "${mockPathOrUrl}" is not compatible with spec file "${specPathOrUrl}"`;
     return { errors, failureReason, success, warnings };
 };
-const validateSpecAndMock = (parsedMock, parsedSpec) => {
+const validateSpecAndMock = (parsedMock, parsedSpec, opts) => {
     const normalizedParsedSpec = (0, to_normalized_parsed_spec_1.toNormalizedParsedSpec)(parsedSpec);
     const normalizedParsedMock = (0, to_normalized_parsed_mock_1.toNormalizedParsedMock)(parsedMock);
     const validationResults = _(normalizedParsedMock.interactions)
-        .map((parsedMockInteraction) => validateMockInteraction(parsedMockInteraction, normalizedParsedSpec))
+        .map((parsedMockInteraction) => validateMockInteraction(parsedMockInteraction, normalizedParsedSpec, opts))
         .flatten()
         .value();
     return Promise.resolve(createValidationOutcome(validationResults, parsedMock.pathOrUrl, parsedSpec.pathOrUrl));

--- a/dist/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.js
+++ b/dist/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.js
@@ -10,14 +10,26 @@ const removeRequiredPropertiesFromSchema = (schema) => {
     const modifiedSchema = _.cloneDeep(schema);
     (0, traverse_json_schema_1.traverseJsonSchema)(modifiedSchema, (mutableSchema) => {
         delete mutableSchema.required;
+        return modifiedSchema;
+    });
+    return modifiedSchema;
+};
+const setAdditionalPropertiesToFalseInSchema = (schema) => {
+    const modifiedSchema = _.cloneDeep(schema);
+    (0, traverse_json_schema_1.traverseJsonSchema)(modifiedSchema, (mutableSchema) => {
+        if (typeof mutableSchema.additionalProperties === 'undefined') {
+            mutableSchema.additionalProperties = false;
+        }
+        return modifiedSchema;
     });
     return modifiedSchema;
 };
 const isMockInteractionWithoutResponseBody = (parsedMockInteraction) => !parsedMockInteraction.responseBody.value;
 const isNotSupportedMediaType = (parsedSpecResponse) => parsedSpecResponse.produces.value.length > 0 &&
     !(0, content_negotiation_1.isMediaTypeSupported)('application/json', parsedSpecResponse.produces.value);
-const shouldSkipValidation = (parsedMockInteraction, parsedSpecResponse) => isMockInteractionWithoutResponseBody(parsedMockInteraction) || isNotSupportedMediaType(parsedSpecResponse);
-const validateParsedMockResponseBody = (parsedMockInteraction, parsedSpecResponse) => {
+const shouldSkipValidation = (parsedMockInteraction, parsedSpecResponse) => isMockInteractionWithoutResponseBody(parsedMockInteraction) ||
+    isNotSupportedMediaType(parsedSpecResponse);
+const validateParsedMockResponseBody = (parsedMockInteraction, parsedSpecResponse, opts) => {
     if (shouldSkipValidation(parsedMockInteraction, parsedSpecResponse)) {
         return [];
     }
@@ -32,8 +44,15 @@ const validateParsedMockResponseBody = (parsedMockInteraction, parsedSpecRespons
             })
         ];
     }
-    const responseBodyWithoutRequiredProperties = removeRequiredPropertiesFromSchema(parsedSpecResponse.schema);
-    const validationErrors = (0, validate_json_1.validateJson)(responseBodyWithoutRequiredProperties, parsedMockInteraction.responseBody.value);
+    let responseBodyToValidate = parsedSpecResponse.schema;
+    // tslint:disable:cyclomatic-complexity
+    if (!opts.additionalPropertiesInResponse) {
+        responseBodyToValidate = setAdditionalPropertiesToFalseInSchema(parsedSpecResponse.schema);
+    }
+    if (!opts.requiredPropertiesInResponse) {
+        responseBodyToValidate = removeRequiredPropertiesFromSchema(responseBodyToValidate);
+    }
+    const validationErrors = (0, validate_json_1.validateJson)(responseBodyToValidate, parsedMockInteraction.responseBody.value);
     return _.map(validationErrors, (error) => {
         const message = error.keyword === 'additionalProperties'
             ? `${error.message} - ${error.params.additionalProperty}`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,89 @@
+# Releasing
+
+We've moved to GitHub Actions for releases.
+
+## How a release works
+
+Releases trigger when the repository recieves the custom repository_dispatch event
+`release-triggered`.
+
+This triggers the `publish.yml` workflow, which in turn
+triggers the gulp task defined in `gulpfile.js`
+The workflow will also create a github release with an appropriate changelog.
+
+Having the release triggered by a custom event is useful for automating
+releases in the future (eg for version bumps in pact dependencies).
+
+### Releasing
+
+The gulp release task is not intended to be run locally. Note that it modifies your git
+settings.
+
+The scripts will:
+
+- Modify git authorship settings
+- Confirm that there would be changes in the changelog after release
+- Run Lint
+- Run Build
+- Run Test
+- Commit an appropriate version bump, changelog and tag
+- Package and publish to npm
+- Push the new commit and tag back to the main branch.
+
+
+## Kicking off a release
+
+You must be able to create a github access token with `repo` scope to the
+cypress-slack-reporter repository.
+
+- Set an environment variable `GITHUB_ACCESS_TOKEN_FOR_PACTFLOW_RELEASES` to this token.
+- Make sure master contains the code you want to release
+- Run one of the following, depending on the class of change
+  - `npm run release-patch`
+  - `npm run release-minor`
+  - `npm run release-major`
+
+Then wait for github to do its magic. It will release the current head of master.
+
+Note that the release script refuses to publish anything that wouldn't
+produce a changelog. Please make sure your commits follow the guidelines in
+`CONTRIBUTING.md`
+
+## If the release fails
+
+The publish is the second to last step, so if the release fails, you don't
+need to do any rollbacks.
+
+However, there is a potential for the push to fail _after_ a publish if there
+are new commits to master since the release started. This is unlikely with
+the current commit frequency, but could still happen. Check the logs to
+determine if npm has a version that doesn't exist in the master branch.
+
+If this has happened, you will need to manually put the release commit in.
+
+```
+# First delete the new tag
+#   somehow this ends up in the repository
+#   even though the push fails.
+
+git checkout master
+git pull --tags
+git tag -d <broken-version>
+git push -delete origin <broken-version>
+
+
+# If there are changes that introduce features, then you'll have to branch and probably rebase
+
+# Now create a new commit + tag for the version:
+npm run release
+
+# Push that tag + commit
+git push origin master --follow-tags
+
+```
+
+- Don't forget to create a new release in github.
+
+Depending on the nature of the new commits to master after the release, you
+may need to rebase them on top of the tagged release commit and force push (only do this
+if the released version would be different to the version tagged by `npm run release`)

--- a/docs/pact.json
+++ b/docs/pact.json
@@ -1,0 +1,39 @@
+{
+  "consumer": {
+    "name": "MyConsumer"
+  },
+  "provider": {
+    "name": "pactWith"
+  },
+  "interactions": [
+    {
+      "description": "A get request to get a pet 1845563262948980200",
+      "providerState": "A pet 1845563262948980200 exists",
+      "request": {
+        "method": "GET",
+        "path": "/v2/pet/1845563262948980200",
+        "headers": {
+          "api_key": "[]"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "someField": "some string"
+        },
+        "matchingRules": {
+          "$.body.someField": {
+            "match": "type"
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    }
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ exports.release = gulp.series(
     commitChanges,
     createNewTag,
     pushChanges,
-    // npmPublish
+    npmPublish
 );
 
 exports.watch = gulp.series(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,8 @@ exports.release = gulp.series(
     commitChanges,
     createNewTag,
     pushChanges,
-    npmPublish
+    // Skipping publish - doing this as a seperate action in GH
+    // npmPublish
 );
 
 exports.watch = gulp.series(

--- a/lib/api-types.d.ts
+++ b/lib/api-types.d.ts
@@ -83,6 +83,8 @@ declare namespace SwaggerMockValidator {
     export interface SwaggerMockValidatorOptions {
         mock: SwaggerMockValidatorOptionsMock;
         spec: SwaggerMockValidatorOptionsSpec;
+        additionalPropertiesInResponse: boolean;
+        requiredPropertiesInResponse: boolean;
     }
 
     export type ErrorCode =

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -51,8 +51,10 @@ commander
     .option('-u, --user [USERNAME:PASSWORD]', 'The basic auth username and password to access the pact broker')
     .option('-a, --analyticsUrl [string]', 'The url to send analytics events to as a http post')
     .option('-o, --outputDepth [integer]', 'Specifies the number of times to recurse ' +
-        'while formatting the output objects. ' +
-        'This is useful in case of large complicated objects or schemas.', parseInt, 4)
+    'while formatting the output objects. ' +
+    'This is useful in case of large complicated objects or schemas.', parseInt, 4)
+    .option('-A, --additionalPropertiesInResponse [boolean]', 'set additionalProperties response body to defined value, defaults true')
+    .option('-R, --requiredPropertiesInResponse [boolean]', 'set additionalProperties response body to required value, default true')
     .description(
 `Confirms the swagger spec and mock are compatible with each other.
 
@@ -82,7 +84,9 @@ If the pact broker has basic auth enabled, pass a --user option with username an
                 mockPathOrUrl: mock,
                 providerName: options.provider,
                 specPathOrUrl: swagger,
-                tag: options.tag
+                tag: options.tag,
+                additionalPropertiesInResponse: options.additionalPropertiesInResponse,
+                requiredPropertiesInResponse: options.requiredPropertiesInResponse
             });
 
             displaySummary(result, options.outputDepth);

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -53,8 +53,8 @@ commander
     .option('-o, --outputDepth [integer]', 'Specifies the number of times to recurse ' +
     'while formatting the output objects. ' +
     'This is useful in case of large complicated objects or schemas.', parseInt, 4)
-    .option('-A, --additionalPropertiesInResponse [boolean]', 'set additionalProperties response body to defined value, defaults true')
-    .option('-R, --requiredPropertiesInResponse [boolean]', 'set additionalProperties response body to required value, default true')
+    .option('-A, --additionalPropertiesInResponse [boolean]', 'allow additional properties in response bodies, default true')
+    .option('-R, --requiredPropertiesInResponse [boolean]', 'allows required properties in response bodies, default false')
     .description(
 `Confirms the swagger spec and mock are compatible with each other.
 

--- a/lib/swagger-mock-validator.ts
+++ b/lib/swagger-mock-validator.ts
@@ -1,191 +1,259 @@
 import * as _ from 'lodash';
+import { ValidationOutcome, ValidationResult } from './api-types';
+import { Analytics } from './swagger-mock-validator/analytics';
+import { FileStore } from './swagger-mock-validator/file-store';
+import { MockParser } from './swagger-mock-validator/mock-parser';
+import { ParsedMock } from './swagger-mock-validator/mock-parser/parsed-mock';
+import { PactBroker } from './swagger-mock-validator/pact-broker';
+import { SpecParser } from './swagger-mock-validator/spec-parser';
 import {
-    ValidationOutcome,
-    ValidationResult
-} from './api-types';
-import {Analytics} from './swagger-mock-validator/analytics';
-import {FileStore} from './swagger-mock-validator/file-store';
-import {MockParser} from './swagger-mock-validator/mock-parser';
-import {ParsedMock} from './swagger-mock-validator/mock-parser/parsed-mock';
-import {PactBroker} from './swagger-mock-validator/pact-broker';
-import {SpecParser} from './swagger-mock-validator/spec-parser';
-import {
-    MockSource,
-    ParsedSwaggerMockValidatorOptions,
-    SerializedMock,
-    SerializedSpec,
-    SpecSource,
-    SwaggerMockValidatorUserOptions,
-    ValidateOptions
+  MockSource,
+  ParsedSwaggerMockValidatorOptions,
+  SerializedMock,
+  SerializedSpec,
+  SpecSource,
+  SwaggerMockValidatorUserOptions,
+  ValidateOptions
 } from './swagger-mock-validator/types';
-import {validateSpecAndMock} from './swagger-mock-validator/validate-spec-and-mock';
+import { validateSpecAndMock } from './swagger-mock-validator/validate-spec-and-mock';
 
-const getMockSource = (mockPathOrUrl: string, providerName?: string): MockSource => {
-    if (providerName) {
-        return 'pactBroker';
-    } else if (FileStore.isUrl(mockPathOrUrl)) {
-        return 'url';
-    }
+const getMockSource = (
+  mockPathOrUrl: string,
+  providerName?: string
+): MockSource => {
+  if (providerName) {
+    return 'pactBroker';
+  } else if (FileStore.isUrl(mockPathOrUrl)) {
+    return 'url';
+  }
 
-    return 'path';
+  return 'path';
 };
 
-const getSpecSource = (specPathOrUrl: string): SpecSource => FileStore.isUrl(specPathOrUrl) ? 'url' : 'path';
+const getSpecSource = (specPathOrUrl: string): SpecSource =>
+  FileStore.isUrl(specPathOrUrl) ? 'url' : 'path';
 
-const parseUserOptions = (userOptions: SwaggerMockValidatorUserOptions): ParsedSwaggerMockValidatorOptions => ({
-    ...userOptions,
-    mockSource: getMockSource(userOptions.mockPathOrUrl, userOptions.providerName),
-    specSource: getSpecSource(userOptions.specPathOrUrl)
+// tslint:disable:cyclomatic-complexity
+const parseUserOptions = (
+  userOptions: SwaggerMockValidatorUserOptions
+): ParsedSwaggerMockValidatorOptions => ({
+  ...userOptions,
+  mockSource: getMockSource(
+    userOptions.mockPathOrUrl,
+    userOptions.providerName
+  ),
+  specSource: getSpecSource(userOptions.specPathOrUrl),
+  additionalPropertiesInResponse:
+    typeof userOptions.additionalPropertiesInResponse === 'undefined'
+      ? true // default to true - existing behaviour
+      : userOptions.additionalPropertiesInResponse === 'true'
+      ? true
+      : false,
+  requiredPropertiesInResponse:
+    typeof userOptions.requiredPropertiesInResponse === 'undefined'
+      ? false // default to false - existing behaviour
+      : userOptions.requiredPropertiesInResponse === 'true'
+      ? true
+      : false
 });
 
-const combineValidationResults = (validationResults: ValidationResult[][]): ValidationResult[] => {
-    const flattenedValidationResults = _.flatten(validationResults);
-    return _.uniqWith(flattenedValidationResults, _.isEqual);
+const combineValidationResults = (
+  validationResults: ValidationResult[][]
+): ValidationResult[] => {
+  const flattenedValidationResults = _.flatten(validationResults);
+  return _.uniqWith(flattenedValidationResults, _.isEqual);
 };
 
-const combineValidationOutcomes = (validationOutcomes: ValidationOutcome[]): ValidationOutcome => {
-    return {
-        errors: combineValidationResults(validationOutcomes.map((validationOutcome) => validationOutcome.errors)),
-        failureReason: _(validationOutcomes)
-            .map((outcome: ValidationOutcome) => outcome.failureReason)
-            .filter((failureReason) => failureReason !== undefined)
-            .join(', ') || undefined,
-        success: _.every(validationOutcomes, (outcome: ValidationOutcome) => outcome.success),
-        warnings: combineValidationResults(validationOutcomes.map((validationOutcome) => validationOutcome.warnings))
-    };
+const combineValidationOutcomes = (
+  validationOutcomes: ValidationOutcome[]
+): ValidationOutcome => {
+  return {
+    errors: combineValidationResults(
+      validationOutcomes.map((validationOutcome) => validationOutcome.errors)
+    ),
+    failureReason:
+      _(validationOutcomes)
+        .map((outcome: ValidationOutcome) => outcome.failureReason)
+        .filter((failureReason) => failureReason !== undefined)
+        .join(', ') || undefined,
+    success: _.every(
+      validationOutcomes,
+      (outcome: ValidationOutcome) => outcome.success
+    ),
+    warnings: combineValidationResults(
+      validationOutcomes.map((validationOutcome) => validationOutcome.warnings)
+    )
+  };
 };
 
 interface ValidationSpecAndMockContentResult {
-    parsedMock?: ParsedMock;
-    validationOutcome: ValidationOutcome;
+  parsedMock?: ParsedMock;
+  validationOutcome: ValidationOutcome;
 }
 
 export const validateSpecAndMockContent = async (
-    options: ValidateOptions
+  options: ValidateOptions
 ): Promise<ValidationSpecAndMockContentResult> => {
-    const spec = options.spec;
-    const mock = options.mock;
+  const spec = options.spec;
+  const mock = options.mock;
+  const opts = ({
+    additionalPropertiesInResponse: options.additionalPropertiesInResponse,
+    requiredPropertiesInResponse: options.requiredPropertiesInResponse
+  } = options);
 
-    const parsedSpec = await SpecParser.parse(spec);
-    const parsedMock = MockParser.parse(mock);
-    const validationOutcome = await validateSpecAndMock(parsedMock, parsedSpec);
+  const parsedSpec = await SpecParser.parse(spec);
+  const parsedMock = MockParser.parse(mock);
+  const validationOutcome = await validateSpecAndMock(
+    parsedMock,
+    parsedSpec,
+    opts
+  );
 
-    return {
-        parsedMock,
-        validationOutcome
-    };
+  return {
+    parsedMock,
+    validationOutcome
+  };
 };
 
 export class SwaggerMockValidator {
-    private static getNoMocksInBrokerValidationOutcome(): ValidationOutcome[] {
-        const noMocksValidationOutcome: ValidationOutcome = {
-            errors: [],
-            success: true,
-            warnings: [{
-                code: 'pact-broker.no-pacts-found',
-                message: 'No consumer pacts found in Pact Broker',
-                source: 'pact-broker',
-                type: 'warning'
-            }]
-        };
-        return [noMocksValidationOutcome];
-    }
-
-    public constructor(
-        private readonly fileStore: FileStore,
-        private readonly pactBroker: PactBroker,
-        private readonly analytics: Analytics) {
-    }
-
-    public async validate(userOptions: SwaggerMockValidatorUserOptions): Promise<ValidationOutcome> {
-        const options = parseUserOptions(userOptions);
-        const {spec, mocks} = await this.loadSpecAndMocks(options);
-
-        const validationOutcomes = await this.getValidationOutcomes(spec, mocks, options);
-
-        return combineValidationOutcomes(validationOutcomes);
-    }
-
-    private async loadSpecAndMocks(
-        options: ParsedSwaggerMockValidatorOptions
-    ): Promise<{ spec: SerializedSpec, mocks: SerializedMock[] }> {
-        const whenSpecContent = this.getSpecFromFileOrUrl(options.specPathOrUrl);
-
-        const whenMocks = options.providerName ?
-            this.pactBroker.loadPacts({
-                pactBrokerUrl: options.mockPathOrUrl,
-                providerName: options.providerName,
-                tag: options.tag
-            }) : this.getPactFromFileOrUrl(options.mockPathOrUrl);
-
-        const [spec, mocks] = await Promise.all([whenSpecContent, whenMocks]);
-        return {spec, mocks};
-    }
-
-    private async getSpecFromFileOrUrl(specPathOrUrl: string): Promise<SerializedSpec> {
-        const content = await this.fileStore.loadFile(specPathOrUrl);
-
-        return {
-            content,
-            format: 'auto-detect',
-            pathOrUrl: specPathOrUrl
-        };
-    }
-
-    private async getPactFromFileOrUrl(mockPathOrUrl: string): Promise<SerializedMock[]> {
-        const content = await this.fileStore.loadFile(mockPathOrUrl);
-
-        return [{
-            content,
-            format: 'auto-detect',
-            pathOrUrl: mockPathOrUrl
-        }];
-    }
-
-    private async getValidationOutcomes(
-        spec: SerializedSpec, mocks: SerializedMock[], options: ParsedSwaggerMockValidatorOptions
-    ): Promise<ValidationOutcome[]> {
-        if (mocks.length === 0) {
-            return SwaggerMockValidator.getNoMocksInBrokerValidationOutcome();
+  private static getNoMocksInBrokerValidationOutcome(): ValidationOutcome[] {
+    const noMocksValidationOutcome: ValidationOutcome = {
+      errors: [],
+      success: true,
+      warnings: [
+        {
+          code: 'pact-broker.no-pacts-found',
+          message: 'No consumer pacts found in Pact Broker',
+          source: 'pact-broker',
+          type: 'warning'
         }
+      ]
+    };
+    return [noMocksValidationOutcome];
+  }
 
-        return Promise.all(
-            mocks.map((mock) => this.validateSpecAndMock(spec, mock, options))
-        );
+  public constructor(
+    private readonly fileStore: FileStore,
+    private readonly pactBroker: PactBroker,
+    private readonly analytics: Analytics
+  ) {}
+
+  public async validate(
+    userOptions: SwaggerMockValidatorUserOptions
+  ): Promise<ValidationOutcome> {
+    const options = parseUserOptions(userOptions);
+    const { spec, mocks } = await this.loadSpecAndMocks(options);
+    const validationOutcomes = await this.getValidationOutcomes(
+      spec,
+      mocks,
+      options
+    );
+
+    return combineValidationOutcomes(validationOutcomes);
+  }
+
+  private async loadSpecAndMocks(
+    options: ParsedSwaggerMockValidatorOptions
+  ): Promise<{ spec: SerializedSpec; mocks: SerializedMock[] }> {
+    const whenSpecContent = this.getSpecFromFileOrUrl(options.specPathOrUrl);
+
+    const whenMocks = options.providerName
+      ? this.pactBroker.loadPacts({
+          pactBrokerUrl: options.mockPathOrUrl,
+          providerName: options.providerName,
+          tag: options.tag
+        })
+      : this.getPactFromFileOrUrl(options.mockPathOrUrl);
+
+    const [spec, mocks] = await Promise.all([whenSpecContent, whenMocks]);
+    return { spec, mocks };
+  }
+
+  private async getSpecFromFileOrUrl(
+    specPathOrUrl: string
+  ): Promise<SerializedSpec> {
+    const content = await this.fileStore.loadFile(specPathOrUrl);
+
+    return {
+      content,
+      format: 'auto-detect',
+      pathOrUrl: specPathOrUrl
+    };
+  }
+
+  private async getPactFromFileOrUrl(
+    mockPathOrUrl: string
+  ): Promise<SerializedMock[]> {
+    const content = await this.fileStore.loadFile(mockPathOrUrl);
+
+    return [
+      {
+        content,
+        format: 'auto-detect',
+        pathOrUrl: mockPathOrUrl
+      }
+    ];
+  }
+
+  private async getValidationOutcomes(
+    spec: SerializedSpec,
+    mocks: SerializedMock[],
+    options: ParsedSwaggerMockValidatorOptions
+  ): Promise<ValidationOutcome[]> {
+    if (mocks.length === 0) {
+      return SwaggerMockValidator.getNoMocksInBrokerValidationOutcome();
     }
 
-    private async validateSpecAndMock(
-        spec: SerializedSpec, mock: SerializedMock, options: ParsedSwaggerMockValidatorOptions
-    ): Promise<ValidationOutcome> {
-        const result = await validateSpecAndMockContent({mock, spec});
+    return Promise.all(
+      mocks.map((mock) => this.validateSpecAndMock(spec, mock, options))
+    );
+  }
 
-        if (result.parsedMock) {
-            await this.postAnalyticEvent(options, result.parsedMock, result.validationOutcome);
-        }
+  private async validateSpecAndMock(
+    spec: SerializedSpec,
+    mock: SerializedMock,
+    options: ParsedSwaggerMockValidatorOptions
+  ): Promise<ValidationOutcome> {
+    const { additionalPropertiesInResponse, requiredPropertiesInResponse } =
+      options;
+    const result = await validateSpecAndMockContent({
+      mock,
+      spec,
+      additionalPropertiesInResponse,
+      requiredPropertiesInResponse
+    });
 
-        return result.validationOutcome;
+    if (result.parsedMock) {
+      await this.postAnalyticEvent(
+        options,
+        result.parsedMock,
+        result.validationOutcome
+      );
     }
 
-    private async postAnalyticEvent(
-        options: ParsedSwaggerMockValidatorOptions,
-        parsedMock: ParsedMock,
-        validationOutcome: ValidationOutcome
-    ): Promise<void> {
-        if (options.analyticsUrl) {
-            try {
-                await this.analytics.postEvent({
-                    analyticsUrl: options.analyticsUrl,
-                    consumer: parsedMock.consumer,
-                    mockPathOrUrl: parsedMock.pathOrUrl,
-                    mockSource: options.mockSource,
-                    provider: parsedMock.provider,
-                    specPathOrUrl: options.specPathOrUrl,
-                    specSource: options.specSource,
-                    validationOutcome
-                });
-            } catch (error) {
-                // do not fail tool on analytics errors
-            }
-        }
+    return result.validationOutcome;
+  }
+
+  private async postAnalyticEvent(
+    options: ParsedSwaggerMockValidatorOptions,
+    parsedMock: ParsedMock,
+    validationOutcome: ValidationOutcome
+  ): Promise<void> {
+    if (options.analyticsUrl) {
+      try {
+        await this.analytics.postEvent({
+          analyticsUrl: options.analyticsUrl,
+          consumer: parsedMock.consumer,
+          mockPathOrUrl: parsedMock.pathOrUrl,
+          mockSource: options.mockSource,
+          provider: parsedMock.provider,
+          specPathOrUrl: options.specPathOrUrl,
+          specSource: options.specSource,
+          validationOutcome
+        });
+      } catch (error) {
+        // do not fail tool on analytics errors
+      }
     }
+  }
 }

--- a/lib/swagger-mock-validator/types.d.ts
+++ b/lib/swagger-mock-validator/types.d.ts
@@ -31,6 +31,8 @@ export interface SwaggerMockValidatorUserOptions {
     providerName?: string;
     specPathOrUrl: string;
     tag?: string;
+    additionalPropertiesInResponse?: string;
+    requiredPropertiesInResponse?: string;
 }
 
 export interface PactBrokerUserOptions {
@@ -60,6 +62,8 @@ export interface SerializedMock {
 export interface ValidateOptions {
     mock: SerializedMock;
     spec: SerializedSpec;
+    additionalPropertiesInResponse: boolean;
+    requiredPropertiesInResponse: boolean;
 }
 
 interface ParsedSwaggerMockValidatorOptions {
@@ -70,6 +74,8 @@ interface ParsedSwaggerMockValidatorOptions {
     specPathOrUrl: string;
     specSource: SpecSource;
     tag?: string;
+    additionalPropertiesInResponse: boolean;
+    requiredPropertiesInResponse: boolean;
 }
 
 export type MockSource = 'pactBroker' | 'path' | 'url';

--- a/lib/swagger-mock-validator/validate-spec-and-mock.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock.ts
@@ -1,89 +1,137 @@
 import * as _ from 'lodash';
-import {ValidationOutcome, ValidationResult} from '../api-types';
-import {ParsedMock, ParsedMockInteraction} from './mock-parser/parsed-mock';
-import {ParsedSpec, ParsedSpecOperation} from './spec-parser/parsed-spec';
-import {getParsedSpecOperation} from './validate-spec-and-mock/get-parsed-spec-operation';
-import {getParsedSpecResponse} from './validate-spec-and-mock/get-parsed-spec-response';
-import {toNormalizedParsedMock} from './validate-spec-and-mock/to-normalized-parsed-mock';
-import {toNormalizedParsedSpec} from './validate-spec-and-mock/to-normalized-parsed-spec';
-import {validateParsedMockRequestBody} from './validate-spec-and-mock/validate-parsed-mock-request-body';
-import {validateParsedMockRequestHeaders} from './validate-spec-and-mock/validate-parsed-mock-request-headers';
-import {validateParsedMockRequestQuery} from './validate-spec-and-mock/validate-parsed-mock-request-query';
-import {validateParsedMockResponseBody} from './validate-spec-and-mock/validate-parsed-mock-response-body';
-import {validateParsedMockResponseHeaders} from './validate-spec-and-mock/validate-parsed-mock-response-headers';
-import {validateParsedSpecConsumes} from './validate-spec-and-mock/validate-parsed-spec-consumes';
-import {validateParsedSpecProduces} from './validate-spec-and-mock/validate-parsed-spec-produces';
-import {validateParsedSpecSecurity} from './validate-spec-and-mock/validate-parsed-spec-security';
+import { ValidationOutcome, ValidationResult } from '../api-types';
+import { ParsedMock, ParsedMockInteraction } from './mock-parser/parsed-mock';
+import { ParsedSpec, ParsedSpecOperation } from './spec-parser/parsed-spec';
+import { ValidateOptions } from './types';
+import { getParsedSpecOperation } from './validate-spec-and-mock/get-parsed-spec-operation';
+import { getParsedSpecResponse } from './validate-spec-and-mock/get-parsed-spec-response';
+import { toNormalizedParsedMock } from './validate-spec-and-mock/to-normalized-parsed-mock';
+import { toNormalizedParsedSpec } from './validate-spec-and-mock/to-normalized-parsed-spec';
+import { validateParsedMockRequestBody } from './validate-spec-and-mock/validate-parsed-mock-request-body';
+import { validateParsedMockRequestHeaders } from './validate-spec-and-mock/validate-parsed-mock-request-headers';
+import { validateParsedMockRequestQuery } from './validate-spec-and-mock/validate-parsed-mock-request-query';
+import { validateParsedMockResponseBody } from './validate-spec-and-mock/validate-parsed-mock-response-body';
+import { validateParsedMockResponseHeaders } from './validate-spec-and-mock/validate-parsed-mock-response-headers';
+import { validateParsedSpecConsumes } from './validate-spec-and-mock/validate-parsed-spec-consumes';
+import { validateParsedSpecProduces } from './validate-spec-and-mock/validate-parsed-spec-produces';
+import { validateParsedSpecSecurity } from './validate-spec-and-mock/validate-parsed-spec-security';
 
 const validateMockInteractionRequest = (
-    parsedMockInteraction: ParsedMockInteraction,
-    parsedSpecOperation: ParsedSpecOperation
-) => _.concat(
+  parsedMockInteraction: ParsedMockInteraction,
+  parsedSpecOperation: ParsedSpecOperation
+) =>
+  _.concat(
     validateParsedSpecConsumes(parsedMockInteraction, parsedSpecOperation),
     validateParsedSpecProduces(parsedMockInteraction, parsedSpecOperation),
     validateParsedSpecSecurity(parsedMockInteraction, parsedSpecOperation),
     validateParsedMockRequestBody(parsedMockInteraction, parsedSpecOperation),
-    validateParsedMockRequestHeaders(parsedMockInteraction, parsedSpecOperation),
+    validateParsedMockRequestHeaders(
+      parsedMockInteraction,
+      parsedSpecOperation
+    ),
     validateParsedMockRequestQuery(parsedMockInteraction, parsedSpecOperation)
-);
+  );
 
 const validateMockInteractionResponse = (
-    parsedMockInteraction: ParsedMockInteraction,
-    parsedSpecOperation: ParsedSpecOperation
+  parsedMockInteraction: ParsedMockInteraction,
+  parsedSpecOperation: ParsedSpecOperation,
+  opts: Pick<
+    ValidateOptions,
+    'additionalPropertiesInResponse' | 'requiredPropertiesInResponse'
+  >
 ) => {
-    const parsedSpecResponseResult = getParsedSpecResponse(parsedMockInteraction, parsedSpecOperation);
+  const parsedSpecResponseResult = getParsedSpecResponse(
+    parsedMockInteraction,
+    parsedSpecOperation
+  );
 
-    if (!parsedSpecResponseResult.found) {
-        return parsedSpecResponseResult.results;
-    }
+  if (!parsedSpecResponseResult.found) {
+    return parsedSpecResponseResult.results;
+  }
 
-    return _.concat(
-        parsedSpecResponseResult.results,
-        validateParsedMockResponseBody(parsedMockInteraction, parsedSpecResponseResult.value),
-        validateParsedMockResponseHeaders(parsedMockInteraction, parsedSpecResponseResult.value)
-    );
+  return _.concat(
+    parsedSpecResponseResult.results,
+    validateParsedMockResponseBody(
+      parsedMockInteraction,
+      parsedSpecResponseResult.value,
+      opts
+    ),
+    validateParsedMockResponseHeaders(
+      parsedMockInteraction,
+      parsedSpecResponseResult.value
+    )
+  );
 };
 
 const validateMockInteraction = (
-    parsedMockInteraction: ParsedMockInteraction,
-    normalizedParsedSpec: ParsedSpec
+  parsedMockInteraction: ParsedMockInteraction,
+  normalizedParsedSpec: ParsedSpec,
+  opts: Pick<
+    ValidateOptions,
+    'additionalPropertiesInResponse' | 'requiredPropertiesInResponse'
+  >
 ): ValidationResult[] => {
-    const getParsedSpecOperationResult = getParsedSpecOperation(parsedMockInteraction, normalizedParsedSpec);
+  const getParsedSpecOperationResult = getParsedSpecOperation(
+    parsedMockInteraction,
+    normalizedParsedSpec
+  );
 
-    if (!getParsedSpecOperationResult.found) {
-        return getParsedSpecOperationResult.results;
-    }
+  if (!getParsedSpecOperationResult.found) {
+    return getParsedSpecOperationResult.results;
+  }
 
-    return _.concat(
-        getParsedSpecOperationResult.results,
-        validateMockInteractionRequest(parsedMockInteraction, getParsedSpecOperationResult.value),
-        validateMockInteractionResponse(parsedMockInteraction, getParsedSpecOperationResult.value)
-    );
+  return _.concat(
+    getParsedSpecOperationResult.results,
+    validateMockInteractionRequest(
+      parsedMockInteraction,
+      getParsedSpecOperationResult.value
+    ),
+    validateMockInteractionResponse(
+      parsedMockInteraction,
+      getParsedSpecOperationResult.value,
+      opts
+    )
+  );
 };
 
 const createValidationOutcome = (
-    validationResults: ValidationResult[],
-    mockPathOrUrl: string,
-    specPathOrUrl: string
+  validationResults: ValidationResult[],
+  mockPathOrUrl: string,
+  specPathOrUrl: string
 ): ValidationOutcome => {
-    const errors = _.filter(validationResults, (res) => res.type === 'error');
-    const warnings = _.filter(validationResults, (res) => res.type === 'warning');
-    const success = errors.length === 0;
-    const failureReason = success
-        ? undefined
-        : `Mock file "${mockPathOrUrl}" is not compatible with spec file "${specPathOrUrl}"`;
+  const errors = _.filter(validationResults, (res) => res.type === 'error');
+  const warnings = _.filter(validationResults, (res) => res.type === 'warning');
+  const success = errors.length === 0;
+  const failureReason = success
+    ? undefined
+    : `Mock file "${mockPathOrUrl}" is not compatible with spec file "${specPathOrUrl}"`;
 
-    return {errors, failureReason, success, warnings};
+  return { errors, failureReason, success, warnings };
 };
 
-export const validateSpecAndMock = (parsedMock: ParsedMock, parsedSpec: ParsedSpec): Promise<ValidationOutcome> => {
-    const normalizedParsedSpec = toNormalizedParsedSpec(parsedSpec);
-    const normalizedParsedMock = toNormalizedParsedMock(parsedMock);
+export const validateSpecAndMock = (
+  parsedMock: ParsedMock,
+  parsedSpec: ParsedSpec,
+  opts: Pick<
+    ValidateOptions,
+    'additionalPropertiesInResponse' | 'requiredPropertiesInResponse'
+  >
+): Promise<ValidationOutcome> => {
+  const normalizedParsedSpec = toNormalizedParsedSpec(parsedSpec);
+  const normalizedParsedMock = toNormalizedParsedMock(parsedMock);
 
-    const validationResults = _(normalizedParsedMock.interactions)
-        .map((parsedMockInteraction) => validateMockInteraction(parsedMockInteraction, normalizedParsedSpec))
-        .flatten()
-        .value();
+  const validationResults = _(normalizedParsedMock.interactions)
+    .map((parsedMockInteraction) =>
+      validateMockInteraction(parsedMockInteraction, normalizedParsedSpec, opts)
+    )
+    .flatten()
+    .value();
 
-    return Promise.resolve(createValidationOutcome(validationResults, parsedMock.pathOrUrl, parsedSpec.pathOrUrl));
+  return Promise.resolve(
+    createValidationOutcome(
+      validationResults,
+      parsedMock.pathOrUrl,
+      parsedSpec.pathOrUrl
+    )
+  );
 };

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
@@ -1,68 +1,119 @@
 import * as Ajv from 'ajv';
 import * as _ from 'lodash';
-import {traverseJsonSchema} from '../common/traverse-json-schema';
-import {ParsedMockInteraction} from '../mock-parser/parsed-mock';
-import {result} from '../result';
-import {ParsedSpecJsonSchema, ParsedSpecResponse} from '../spec-parser/parsed-spec';
-import {isMediaTypeSupported} from './content-negotiation';
-import {validateJson} from './validate-json';
+import { traverseJsonSchema } from '../common/traverse-json-schema';
+import { ParsedMockInteraction } from '../mock-parser/parsed-mock';
+import { result } from '../result';
+import {
+  ParsedSpecJsonSchema,
+  ParsedSpecResponse
+} from '../spec-parser/parsed-spec';
+import { ValidateOptions } from '../types';
+import { isMediaTypeSupported } from './content-negotiation';
+import { validateJson } from './validate-json';
 
-const removeRequiredPropertiesFromSchema = (schema: ParsedSpecJsonSchema): ParsedSpecJsonSchema => {
-    const modifiedSchema = _.cloneDeep(schema);
+const removeRequiredPropertiesFromSchema = (
+  schema: ParsedSpecJsonSchema
+): ParsedSpecJsonSchema => {
+  const modifiedSchema = _.cloneDeep(schema);
 
-    traverseJsonSchema(modifiedSchema, (mutableSchema) => {
-        delete mutableSchema.required;
-    });
+  traverseJsonSchema(modifiedSchema, (mutableSchema) => {
+    delete mutableSchema.required;
 
     return modifiedSchema;
+  });
+
+  return modifiedSchema;
 };
 
-const isMockInteractionWithoutResponseBody = (parsedMockInteraction: ParsedMockInteraction) =>
-    !parsedMockInteraction.responseBody.value;
+const setAdditionalPropertiesToFalseInSchema = (
+  schema: ParsedSpecJsonSchema
+): ParsedSpecJsonSchema => {
+  const modifiedSchema = _.cloneDeep(schema);
+
+  traverseJsonSchema(modifiedSchema, (mutableSchema) => {
+    if (typeof mutableSchema.additionalProperties === 'undefined') {
+      mutableSchema.additionalProperties = false;
+    }
+    return modifiedSchema;
+  });
+
+  return modifiedSchema;
+};
+
+const isMockInteractionWithoutResponseBody = (
+  parsedMockInteraction: ParsedMockInteraction
+) => !parsedMockInteraction.responseBody.value;
 
 const isNotSupportedMediaType = (parsedSpecResponse: ParsedSpecResponse) =>
-    parsedSpecResponse.produces.value.length > 0 &&
-    !isMediaTypeSupported('application/json', parsedSpecResponse.produces.value);
+  parsedSpecResponse.produces.value.length > 0 &&
+  !isMediaTypeSupported('application/json', parsedSpecResponse.produces.value);
 
-const shouldSkipValidation = (parsedMockInteraction: ParsedMockInteraction, parsedSpecResponse: ParsedSpecResponse) =>
-    isMockInteractionWithoutResponseBody(parsedMockInteraction) || isNotSupportedMediaType(parsedSpecResponse);
+const shouldSkipValidation = (
+  parsedMockInteraction: ParsedMockInteraction,
+  parsedSpecResponse: ParsedSpecResponse
+) =>
+  isMockInteractionWithoutResponseBody(parsedMockInteraction) ||
+  isNotSupportedMediaType(parsedSpecResponse);
 
-export const validateParsedMockResponseBody = (parsedMockInteraction: ParsedMockInteraction,
-                                               parsedSpecResponse: ParsedSpecResponse) => {
-    if (shouldSkipValidation(parsedMockInteraction, parsedSpecResponse)) {
-        return [];
-    }
+export const validateParsedMockResponseBody = (
+  parsedMockInteraction: ParsedMockInteraction,
+  parsedSpecResponse: ParsedSpecResponse,
+  opts: Pick<
+    ValidateOptions,
+    'additionalPropertiesInResponse' | 'requiredPropertiesInResponse'
+  >
+) => {
+  if (shouldSkipValidation(parsedMockInteraction, parsedSpecResponse)) {
+    return [];
+  }
 
-    if (!parsedSpecResponse.schema) {
-        return [
-            result.build({
-                code: 'response.body.unknown',
-                message: 'No schema found for response body',
-                mockSegment: parsedMockInteraction.responseBody,
-                source: 'spec-mock-validation',
-                specSegment: parsedSpecResponse
-            })
-        ];
-    }
+  if (!parsedSpecResponse.schema) {
+    return [
+      result.build({
+        code: 'response.body.unknown',
+        message: 'No schema found for response body',
+        mockSegment: parsedMockInteraction.responseBody,
+        source: 'spec-mock-validation',
+        specSegment: parsedSpecResponse
+      })
+    ];
+  }
 
-    const responseBodyWithoutRequiredProperties = removeRequiredPropertiesFromSchema(parsedSpecResponse.schema);
+  let responseBodyToValidate: ParsedSpecJsonSchema = parsedSpecResponse.schema;
 
-    const validationErrors = validateJson(
-        responseBodyWithoutRequiredProperties,
-        parsedMockInteraction.responseBody.value
+  // tslint:disable:cyclomatic-complexity
+  if (!opts.additionalPropertiesInResponse) {
+    responseBodyToValidate = setAdditionalPropertiesToFalseInSchema(
+      parsedSpecResponse.schema
     );
+  }
+  if (!opts.requiredPropertiesInResponse) {
+    responseBodyToValidate = removeRequiredPropertiesFromSchema(
+      responseBodyToValidate
+    );
+  }
 
-    return _.map(validationErrors, (error) => {
-        const message = error.keyword === 'additionalProperties'
-            ? `${error.message} - ${(error.params as Ajv.AdditionalPropertiesParams).additionalProperty}`
-            : error.message;
+  const validationErrors = validateJson(
+    responseBodyToValidate,
+    parsedMockInteraction.responseBody.value
+  );
 
-        return result.build({
-            code: 'response.body.incompatible',
-            message: `Response body is incompatible with the response body schema in the spec file: ${message}`,
-            mockSegment: parsedMockInteraction.getResponseBodyPath(error.dataPath),
-            source: 'spec-mock-validation',
-            specSegment: parsedSpecResponse.getFromSchema(error.schemaPath.replace(/\//g, '.').substring(2))
-        });
+  return _.map(validationErrors, (error) => {
+    const message =
+      error.keyword === 'additionalProperties'
+        ? `${error.message} - ${
+            (error.params as Ajv.AdditionalPropertiesParams).additionalProperty
+          }`
+        : error.message;
+
+    return result.build({
+      code: 'response.body.incompatible',
+      message: `Response body is incompatible with the response body schema in the spec file: ${message}`,
+      mockSegment: parsedMockInteraction.getResponseBodyPath(error.dataPath),
+      source: 'spec-mock-validation',
+      specSegment: parsedSpecResponse.getFromSchema(
+        error.schemaPath.replace(/\//g, '.').substring(2)
+      )
     });
+  });
 };

--- a/test/e2e/api.spec.ts
+++ b/test/e2e/api.spec.ts
@@ -33,7 +33,9 @@ describe('swagger-mock-validator/api', () => {
                 content: specContent,
                 format: 'swagger2',
                 pathOrUrl: specPath
-            }
+            },
+            additionalPropertiesInResponse: true,
+            requiredPropertiesInResponse: false
         });
 
         expect(result).toEqual({
@@ -80,7 +82,9 @@ describe('swagger-mock-validator/api', () => {
                 content: specContent,
                 format: 'swagger2',
                 pathOrUrl: specPath
-            }
+            },
+            additionalPropertiesInResponse: true,
+            requiredPropertiesInResponse: false
         });
 
         expect(result.errors.length).toBe(23, 'result.errors.length');
@@ -129,7 +133,9 @@ describe('swagger-mock-validator/api', () => {
                 content: specContent,
                 format: 'swagger2',
                 pathOrUrl: 'not-a-swagger-file.json'
-            }
+            },
+            additionalPropertiesInResponse: true,
+            requiredPropertiesInResponse: false
         }));
 
         expect(error.message).toEqual(jasmine.stringMatching(
@@ -151,7 +157,9 @@ describe('swagger-mock-validator/api', () => {
                 content: specContent,
                 format: 'swagger2',
                 pathOrUrl: 'spec.json'
-            }
+            },
+            additionalPropertiesInResponse: true,
+            requiredPropertiesInResponse: false
         }));
 
         expect(error).toEqual(new SwaggerMockValidatorErrorImpl(
@@ -173,7 +181,9 @@ describe('swagger-mock-validator/api', () => {
                 content: specContent,
                 format: 'openapi3',
                 pathOrUrl: 'spec.json'
-            }
+            },
+            additionalPropertiesInResponse: true,
+            requiredPropertiesInResponse: false
         }));
 
         expect(error).toEqual(new SwaggerMockValidatorErrorImpl(
@@ -195,7 +205,9 @@ describe('swagger-mock-validator/api', () => {
                 content: specContent,
                 format: 'unknown-format' as any,
                 pathOrUrl: 'spec.json'
-            }
+            },
+            additionalPropertiesInResponse: true,
+            requiredPropertiesInResponse: false
         }));
 
         expect(error).toEqual(new SwaggerMockValidatorErrorImpl(


### PR DESCRIPTION
Background
___

Issue raised by Tim Jones on Parent repo - https://bitbucket.org/atlassian/swagger-mock-validator/issues/84/test-incorrectly-passes-when-mock-expects

And noted in the [FAQ](https://github.com/pactflow/swagger-mock-validator/blob/master/FAQ.md#i-have-a-misspelled-property-in-my-pact-response-body-but-swagger-mock-validator-says-that-this-is-valid-why)

Solution
___


This PR will address it by providing configurability for the users options, to conditionally set either flag.

I have added an example pact file, and swagger url to the readme for examples, demonstrating the challenges discussed with either of the approaches


See the readme for illustrative examples 👍🏾 