### PR TITLE
fix: Convert pact spec 3 headers to v1 format

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,6 +55,15 @@ To get fast test feedback run `npm run watch` in one terminal window and `npm ru
 - `npm run watch-e2e` - Automatically runs the e2e tests whenever you edit a relevant file. This command does not
 compile the code and must be run in combination with the watch command.
 
+### Run progam locally
+
+To run the compiled development code locally change to the bin directory and run the swagger-mock-validator-local app via node. This compiled version preserves any console logs for development purposes.
+
+```
+cd bin
+node swagger-mock-validator-local <example_swagger_json> <example_pactfile_json> --outputDepth 5
+```
+
 ## Releasing a new version
 
 This project is versioned using [Semantic Versioning](http://semver.org/).

--- a/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
@@ -1,9 +1,10 @@
 import * as _ from 'lodash';
 import * as querystring from 'querystring';
 import {
-    MultiCollectionFormatSeparator} from '../../types';
-import {ParsedMock, ParsedMockInteraction, ParsedMockValueCollection} from '../parsed-mock';
-import {Pact, PactInteraction, PactInteractionHeaders, PactV1RequestQuery, PactV3RequestQuery} from './pact';
+    MultiCollectionFormatSeparator
+} from '../../types';
+import { ParsedMock, ParsedMockInteraction, ParsedMockValueCollection } from '../parsed-mock';
+import { Pact, PactInteraction, PactInteractionHeaders, PactV1RequestQuery, PactV3RequestQuery } from './pact';
 
 const parseRequestPathSegments = (requestPath: string, parentInteraction: ParsedMockInteraction) =>
     _(requestPath.split('/'))
@@ -16,7 +17,7 @@ const parseRequestPathSegments = (requestPath: string, parentInteraction: Parsed
         .value();
 
 const parseValues = (
-    values: {[name: string]: string} | undefined,
+    values: { [name: string]: string } | undefined,
     location: string,
     parentInteraction: ParsedMockInteraction
 ): ParsedMockValueCollection => {
@@ -34,25 +35,40 @@ const parseValues = (
     );
 };
 
+const parseHeaders = (
+    headers: any | undefined,
+    location: string,
+    parentInteraction: ParsedMockInteraction
+) => {
+    for (const key in headers) {
+        if (typeof headers[key] !== 'string') {
+            headers[key] = headers[key].toString()
+        }
+    }
+    return parseValues(
+        headers, location, parentInteraction
+    );
+}
+
 const isPactV1RequestQuery = (query: PactV1RequestQuery | PactV3RequestQuery): query is PactV1RequestQuery =>
     typeof query === 'string'
 
-const parseAsPactV1RequestQuery = (requestQuery: PactV1RequestQuery): {[name: string]: string} => {
+const parseAsPactV1RequestQuery = (requestQuery: PactV1RequestQuery): { [name: string]: string } => {
     const parsedQueryAsStringsOrArrayOfStrings = querystring.parse(requestQuery);
     const separator: MultiCollectionFormatSeparator = '[multi-array-separator]';
 
     return Object.keys(parsedQueryAsStringsOrArrayOfStrings)
-        .reduce<{[name: string]: string}>((accumulator, queryName) => {
+        .reduce<{ [name: string]: string }>((accumulator, queryName) => {
             const queryValue = parsedQueryAsStringsOrArrayOfStrings[queryName] || '';
             accumulator[queryName] = (queryValue instanceof Array) ? queryValue.join(separator) : queryValue;
             return accumulator;
         }, {});
 };
 
-const parseAsPactV3RequestQuery = (requestQuery: PactV3RequestQuery): {[name: string]: string} => {
+const parseAsPactV3RequestQuery = (requestQuery: PactV3RequestQuery): { [name: string]: string } => {
     const separator: MultiCollectionFormatSeparator = '[multi-array-separator]';
     return Object.keys(requestQuery)
-        .reduce<{[name: string]: string}>((accumulator, queryName) => {
+        .reduce<{ [name: string]: string }>((accumulator, queryName) => {
             accumulator[queryName] = requestQuery[queryName].join(separator);
             return accumulator;
         }, {});
@@ -60,7 +76,7 @@ const parseAsPactV3RequestQuery = (requestQuery: PactV3RequestQuery): {[name: st
 
 const parseRequestQuery = (
     requestQuery: PactV1RequestQuery | PactV3RequestQuery | undefined
-): {[name: string]: string} => {
+): { [name: string]: string } => {
     requestQuery = requestQuery || ''
 
     return isPactV1RequestQuery(requestQuery)
@@ -106,7 +122,7 @@ const parseInteraction = (
         parentInteraction: parsedInteraction,
         value: interaction.request.body
     };
-    parsedInteraction.requestHeaders = parseValues(
+    parsedInteraction.requestHeaders = parseHeaders(
         interaction.request.headers, `${parsedInteraction.location}.request.headers`, parsedInteraction
     );
     parsedInteraction.requestMethod = {
@@ -120,7 +136,7 @@ const parseInteraction = (
         value: interaction.request.path
     };
     parsedInteraction.requestPathSegments = parseRequestPathSegments(interaction.request.path, parsedInteraction);
-    parsedInteraction.requestQuery =  parseValues(
+    parsedInteraction.requestQuery = parseValues(
         parseRequestQuery(interaction.request.query), `${parsedInteraction.location}.request.query`, parsedInteraction
     );
     parsedInteraction.responseBody = {
@@ -128,7 +144,7 @@ const parseInteraction = (
         parentInteraction: parsedInteraction,
         value: interaction.response.body
     };
-    parsedInteraction.responseHeaders = parseValues(
+    parsedInteraction.responseHeaders = parseHeaders(
         interaction.response.headers, `${parsedInteraction.location}.response.headers`, parsedInteraction
     );
     parsedInteraction.responseStatus = {

--- a/test/unit/pact-parser.spec.ts
+++ b/test/unit/pact-parser.spec.ts
@@ -1,0 +1,48 @@
+import * as _ from 'lodash';
+import { pactParser } from '../../lib/swagger-mock-validator/mock-parser/pact/pact-parser';
+import { validateAndResolvePact } from '../../lib/swagger-mock-validator/validate-and-resolve-pact';
+
+describe('pact-parser', () => {
+    it('should convert V3 formatted headers to v1 headers', () => {
+        const pactV3Json = {
+            'consumer': {
+                'name': 'ExampleConsumer'
+            },
+            'interactions': [
+                {
+                    'name': 'sdfsdfsdf',
+                    'description': 'a request to retrieve a product with existing id',
+                    'request': {
+                        'headers': {
+                            'Content-Type': ['text/json'],
+                            'Accept': ['text/plain', 'application/json', 'text/json']
+                        },
+                        'method': 'GET',
+                        'path': '/products/27'
+                    },
+                    'response': {
+                        'body': {
+                            'id': 27,
+                            'name': 'burger',
+                            'type': 'food'
+                        },
+                        'headers': {
+                            'Content-Type': ['application/json']
+                        },
+                        'status': 200
+                    }
+                }
+            ],
+            'provider': {
+                'name': 'ExampleProvider'
+            }
+        }
+
+        const resolvedPact = validateAndResolvePact(pactV3Json, '../../pact_examples/pact.json');
+
+
+        const pact = pactParser.parse(resolvedPact, 'sdfsdf')
+        expect(pact.interactions[0].requestHeaders.Accept.value).toEqual('text/plain,application/json,text/json')
+        expect(pact.interactions[0].requestHeaders['Content-Type'].value).toEqual('text/json')
+    });
+});


### PR DESCRIPTION
To make this tool compatible with version 3 of the pact specification (and upwards) I have included code to convert an array of header values into the expected comma separated string of values. This operation takes place prior to the rest of the logic so that no deeper changes to the logic are required.