### PR TITLE
Add issue with wildcards in OpenAPI spec media types to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -111,3 +111,70 @@ I'd make these two suggestions to help reduce the impact of the false negative c
 
 - If possible, always set additional properties to false on all response schema objects. This avoids the false negative case completely.
 - Using a tool to detect backward incompatible changes to the swagger file. We have been working on a tool called openapi-diff that will detect breaking changes between two swagger/openapi files that may help, although it is still a work in progress.
+
+## Pactflow fails my contract verification, stating that the 'Response Body Contains Unknown Information'. My OpenAPI specification is valid and matches the expectations in my consumer contract. How come?
+
+Here's one reason that this error occurs when verifying your bidirectional contracts.
+
+The current OpenAPI specification supports wildcards for the `content` field defining the media type of a response payload. See [this section in the OpenAPI 3.1.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#fixed-fields-15) for more details.
+
+It allows developers to support different media types (e.g., JSON and XML) for the response payloads without having to define separate specifications.
+
+So, for example, this snippet defining responses for an operation is valid, according to the OpenAPI specification:
+
+```json
+"responses": {
+    "404": {
+        "description": "Not Found"
+    },
+    "400": {
+        "description": "Bad Request"
+    },
+    "200": {
+        "description": "OK",
+        "content": {
+            "*/*": {
+                "schema": {
+                    "$ref": "#/components/schemas/Address"
+                }
+            }
+        }
+    }
+}
+```
+
+where `Address` is an [OpenAPI Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject).
+
+
+However, these wildcards are not supported by the swagger mock validator. Using an OpenAPI specification containing these wildcards will result in the aforementioned error, with Pactflow reporting:
+
+```text
+Response Body Contains Unknown Information.
+
+No schema found for response body
+```
+
+The recommended solution is to replace the wildcards with the applicable specific content type, such as `application/json`:
+
+```json
+"responses": {
+    "404": {
+        "description": "Not Found"
+    },
+    "400": {
+        "description": "Bad Request"
+    },
+    "200": {
+        "description": "OK",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$ref": "#/components/schemas/Address"
+                }
+            }
+        }
+    }
+}
+```
+
+If there are indeed no mismatches between expectations in the consumer bidirectional contract and the provider specification contract, Pactflow will upon reverification no longer fail the bidirectional contract verification.


### PR DESCRIPTION
This PR adds to the FAQ the following situation:

OpenAPI specifications support wildcards when specifying response media types. However, the swagger-mock-validator reports 'Response Body Contains Unknown Information  No schema found for response body' when it encounters these wildcards, even when the consumer and provider contract are fully compatible.

The FAQ proposes the solution of replacing the media type containing wildcard(s) with a more specific media type, which will result in successful verification.