### PR TITLE
feat: filter requests by type to support v4

### DIFF
--- a/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
@@ -156,8 +156,8 @@ const parseInteraction = (
     return parsedInteraction;
 };
 
-const filterUnsupportedTypes = (interaction: PactInteraction)=> {
-    if(!interaction?.type || interaction.type === 'Synchronous/HTTP'){
+const filterUnsupportedTypes = (interaction: PactInteraction) => {
+    if (!interaction?.type || interaction.type === 'Synchronous/HTTP') {
         return interaction
     }
     return null

--- a/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
@@ -156,10 +156,17 @@ const parseInteraction = (
     return parsedInteraction;
 };
 
+const filterUnsupportedTypes = (interaction: PactInteraction)=> {
+    if(!interaction?.type || interaction.type === 'Synchronous/HTTP'){
+        return interaction
+    }
+    return null
+}
+
 export const pactParser = {
     parse: (pactJson: Pact, mockPathOrUrl: string): ParsedMock => ({
         consumer: pactJson.consumer.name,
-        interactions: pactJson.interactions.filter(interaction => interaction?.type !== 'Asynchronous/Messages').map((interaction: PactInteraction, interactionIndex: number) =>
+        interactions: pactJson.interactions.filter(interaction => filterUnsupportedTypes(interaction)).map((interaction: PactInteraction, interactionIndex: number) =>
             parseInteraction(interaction, interactionIndex, mockPathOrUrl)
         ),
         pathOrUrl: mockPathOrUrl,

--- a/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
@@ -96,6 +96,8 @@ const parseInteraction = (
         value: interaction
     } as ParsedMockInteraction;
 
+
+    console.log('interaction', interaction)
     const getBodyPath = (bodyValue: any, bodyLocation: string, path: string) => {
         let location = bodyLocation;
         let value = bodyValue;
@@ -113,9 +115,9 @@ const parseInteraction = (
     };
 
     parsedInteraction.getRequestBodyPath = (path) =>
-        getBodyPath(interaction.request.body, `${parsedInteraction.location}.request.body`, path);
+        getBodyPath(interaction?.request?.body, `${parsedInteraction.location}.request.body`, path);
     parsedInteraction.getResponseBodyPath = (path) =>
-        getBodyPath(interaction.response.body, `${parsedInteraction.location}.response.body`, path);
+        getBodyPath(interaction?.response?.body, `${parsedInteraction.location}.response.body`, path);
     parsedInteraction.parentInteraction = parsedInteraction;
     parsedInteraction.requestBody = {
         location: `${parsedInteraction.location}.request.body`,
@@ -159,7 +161,7 @@ const parseInteraction = (
 export const pactParser = {
     parse: (pactJson: Pact, mockPathOrUrl: string): ParsedMock => ({
         consumer: pactJson.consumer.name,
-        interactions: pactJson.interactions.map((interaction: PactInteraction, interactionIndex: number) =>
+        interactions: pactJson.interactions.filter(interaction => interaction?.type !== 'Asynchronous/Messages').map((interaction: PactInteraction, interactionIndex: number) =>
             parseInteraction(interaction, interactionIndex, mockPathOrUrl)
         ),
         pathOrUrl: mockPathOrUrl,

--- a/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
@@ -96,8 +96,6 @@ const parseInteraction = (
         value: interaction
     } as ParsedMockInteraction;
 
-
-    console.log('interaction', interaction)
     const getBodyPath = (bodyValue: any, bodyLocation: string, path: string) => {
         let location = bodyLocation;
         let value = bodyValue;

--- a/lib/swagger-mock-validator/mock-parser/pact/pact.d.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact.d.ts
@@ -6,6 +6,7 @@ export interface Pact {
 }
 
 export interface PactInteraction {
+    type?: string;
     description: string;
     request: PactInteractionRequest;
     response: PactInteractionResponse;

--- a/test/e2e/api.spec.ts
+++ b/test/e2e/api.spec.ts
@@ -89,6 +89,33 @@ describe('swagger-mock-validator/api', () => {
             expect(result.errors.length).toEqual(0)
             expect(result.warnings.length).toEqual(0)
     });
+
+    it('should pass when the pact file is v4 format', async () => {
+        const specPath = 'test/e2e/fixtures/pactv3-compatible-swagger.yaml';
+        const mockPath = 'test/e2e/fixtures/v4-pact-file.json';
+
+        const specContent = await loadContent(specPath);
+        const mockContent = await loadContent(mockPath);
+        
+        const result = await SwaggerMockValidator.validate({
+            mock: {
+                content: mockContent,
+                format: 'pact',
+                pathOrUrl: mockPath
+            },
+            spec: {
+                content: specContent,
+                format: 'openapi3',
+                pathOrUrl: specPath
+            },
+            additionalPropertiesInResponse: false,
+            requiredPropertiesInResponse: false
+        });
+
+        expect(result.errors.length).toEqual(0)
+        expect(result.warnings.length).toEqual(0)
+    });
+
     it('should succeed with validation errors when a pact file and a swagger file are not compatible', async () => {
         const specPath = 'test/e2e/fixtures/swagger-provider.json';
         const mockPath = 'test/e2e/fixtures/pact-broken-consumer.json';

--- a/test/e2e/api.spec.ts
+++ b/test/e2e/api.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as SwaggerMockValidator from '../../lib/api';
-import {SwaggerMockValidatorErrorImpl} from '../../lib/swagger-mock-validator/swagger-mock-validator-error-impl';
-import {expectToFail} from '../support/expect-to-fail';
+import { SwaggerMockValidatorErrorImpl } from '../../lib/swagger-mock-validator/swagger-mock-validator-error-impl';
+import { expectToFail } from '../support/expect-to-fail';
 
 describe('swagger-mock-validator/api', () => {
     const loadContent = (filePath: string): Promise<string> => {
@@ -71,7 +71,7 @@ describe('swagger-mock-validator/api', () => {
 
         const specContent = await loadContent(specPath);
         const mockContent = await loadContent(mockPath);
-        
+
         const result = await SwaggerMockValidator.validate({
             mock: {
                 content: mockContent,
@@ -86,8 +86,8 @@ describe('swagger-mock-validator/api', () => {
             additionalPropertiesInResponse: true,
             requiredPropertiesInResponse: false
         });
-            expect(result.errors.length).toEqual(0)
-            expect(result.warnings.length).toEqual(0)
+        expect(result.errors.length).toEqual(0)
+        expect(result.warnings.length).toEqual(0)
     });
 
     it('should pass when the pact file is v4 format', async () => {
@@ -96,7 +96,7 @@ describe('swagger-mock-validator/api', () => {
 
         const specContent = await loadContent(specPath);
         const mockContent = await loadContent(mockPath);
-        
+
         const result = await SwaggerMockValidator.validate({
             mock: {
                 content: mockContent,
@@ -195,8 +195,8 @@ describe('swagger-mock-validator/api', () => {
     }, 30000);
 
     it('should fail when the format is swagger2 but the content is not', async () => {
-        const specContent = JSON.stringify({not: 'swagger2'});
-        const mockContent = JSON.stringify({interactions: []});
+        const specContent = JSON.stringify({ not: 'swagger2' });
+        const mockContent = JSON.stringify({ interactions: [] });
 
         const error = await expectToFail(SwaggerMockValidator.validate({
             mock: {
@@ -219,8 +219,8 @@ describe('swagger-mock-validator/api', () => {
     });
 
     it('should fail when the format is openapi3 but the content is not', async () => {
-        const specContent = JSON.stringify({openapi: '4.0'});
-        const mockContent = JSON.stringify({interactions: []});
+        const specContent = JSON.stringify({ openapi: '4.0' });
+        const mockContent = JSON.stringify({ interactions: [] });
 
         const error = await expectToFail(SwaggerMockValidator.validate({
             mock: {
@@ -243,8 +243,8 @@ describe('swagger-mock-validator/api', () => {
     });
 
     it('should fail when the given format is unknown', async () => {
-        const specContent = JSON.stringify({unknown: 'spec format'});
-        const mockContent = JSON.stringify({interactions: []});
+        const specContent = JSON.stringify({ unknown: 'spec format' });
+        const mockContent = JSON.stringify({ interactions: [] });
 
         const error = await expectToFail(SwaggerMockValidator.validate({
             mock: {

--- a/test/e2e/api.spec.ts
+++ b/test/e2e/api.spec.ts
@@ -65,6 +65,30 @@ describe('swagger-mock-validator/api', () => {
         });
     }, 30000);
 
+    it('should pass when the pact file is v3 format', async () => {
+        const specPath = 'test/e2e/fixtures/pactv3-compatible-swagger.yaml';
+        const mockPath = 'test/e2e/fixtures/v3-pact-file.json';
+
+        const specContent = await loadContent(specPath);
+        const mockContent = await loadContent(mockPath);
+        
+        const result = await SwaggerMockValidator.validate({
+            mock: {
+                content: mockContent,
+                format: 'pact',
+                pathOrUrl: mockPath
+            },
+            spec: {
+                content: specContent,
+                format: 'openapi3',
+                pathOrUrl: specPath
+            },
+            additionalPropertiesInResponse: true,
+            requiredPropertiesInResponse: false
+        });
+            expect(result.errors.length).toEqual(0)
+            expect(result.warnings.length).toEqual(0)
+    });
     it('should succeed with validation errors when a pact file and a swagger file are not compatible', async () => {
         const specPath = 'test/e2e/fixtures/swagger-provider.json';
         const mockPath = 'test/e2e/fixtures/pact-broken-consumer.json';

--- a/test/e2e/api.spec.ts
+++ b/test/e2e/api.spec.ts
@@ -91,7 +91,7 @@ describe('swagger-mock-validator/api', () => {
     });
 
     it('should pass when the pact file is v4 format', async () => {
-        const specPath = 'test/e2e/fixtures/pactv3-compatible-swagger.yaml';
+        const specPath = 'test/e2e/fixtures/pactv4-compatible-swagger.yaml';
         const mockPath = 'test/e2e/fixtures/v4-pact-file.json';
 
         const specContent = await loadContent(specPath);
@@ -108,7 +108,7 @@ describe('swagger-mock-validator/api', () => {
                 format: 'openapi3',
                 pathOrUrl: specPath
             },
-            additionalPropertiesInResponse: false,
+            additionalPropertiesInResponse: true,
             requiredPropertiesInResponse: false
         });
 

--- a/test/e2e/fixtures/pactv3-compatible-swagger.yaml
+++ b/test/e2e/fixtures/pactv3-compatible-swagger.yaml
@@ -1,0 +1,122 @@
+openapi: 3.0.1
+info:
+  title: Product API
+  description: Pactflow Product API demo
+  version: 1.0.0
+paths:
+  /products:
+    post:
+      summary: Create a product
+      description: Creates a new product
+      operationId: createProduct
+      requestBody:
+        description: Create a new Product
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+            examples:
+              application/json:
+                value:
+                  id: "1234"
+                  type: "food"
+                  price: 42
+      responses:
+        "200":
+          description: successful operation
+          content:
+            "application/json; charset=utf-8":
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Product'
+              examples:
+                application/json:
+                  value:
+                    id: "1234"
+                    type: "food"
+                    price: 42
+    get:
+      summary: List all products
+      description: Returns all products
+      parameters:
+      - name: max_results
+        in: query
+        description: '{"max_results":100}'
+        required: true
+        schema:
+          type: integer
+      operationId: getAllProducts
+      responses:
+        "200":
+          description: successful operation
+          content:
+            "application/json; charset=utf-8":
+              schema:
+                type: "array"
+                items:
+                  $ref: '#/components/schemas/Product'
+              examples:
+                application/json:
+                  value:
+                    - id: "1234"
+                      type: "food"
+                      price: 42
+        "400":
+          description: Invalid ID supplied
+          content: {}
+  /product/{id}:
+    get:
+      summary: Find product by ID
+      description: Returns a single product
+      operationId: getProductByID
+      parameters:
+      - name: id
+        in: path
+        description: ID of product to get
+        schema:
+          type: string
+        required: true
+        example: 10
+      responses:
+        "200":
+          description: successful operation
+          content:
+            "application/json; charset=utf-8":
+              schema:
+                $ref: '#/components/schemas/Product'
+              examples:
+                application/json:
+                  value:
+                    id: "1234"
+                    type: "food"
+                    price: 42
+                    # name: "pizza"
+                    # version: "1.0.0"
+                    # see https://github.com/apiaryio/dredd/issues/1430 for why
+        "400":
+          description: Invalid ID supplied
+          content: {}
+        "404":
+          description: Product not found
+          content: {}
+components:
+  schemas:
+    Product:
+      type: object
+      required:
+        - id
+        - name
+        - price
+      additionalProperties: false # WARNING! without this, a consumer can add stuff that doesn't exist! See also https://bitbucket.org/atlassian/swagger-mock-validator/issues/84/test-incorrectly-passes-when-mock-expects
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        price:
+          type: number

--- a/test/e2e/fixtures/pactv4-compatible-swagger.yaml
+++ b/test/e2e/fixtures/pactv4-compatible-swagger.yaml
@@ -1,0 +1,122 @@
+openapi: 3.0.1
+info:
+  title: Product API
+  description: Pactflow Product API demo
+  version: 1.0.0
+paths:
+  /products:
+    post:
+      summary: Create a product
+      description: Creates a new product
+      operationId: createProduct
+      requestBody:
+        description: Create a new Product
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+            examples:
+              application/json:
+                value:
+                  id: "1234"
+                  type: "food"
+                  price: 42
+      responses:
+        "200":
+          description: successful operation
+          content:
+            "application/json; charset=utf-8":
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Product'
+              examples:
+                application/json:
+                  value:
+                    id: "1234"
+                    type: "food"
+                    price: 42
+    get:
+      summary: List all products
+      description: Returns all products
+      parameters:
+      - name: max_results
+        in: query
+        description: '{"max_results":100}'
+        required: true
+        schema:
+          type: integer
+      operationId: getAllProducts
+      responses:
+        "200":
+          description: successful operation
+          content:
+            "application/json; charset=utf-8":
+              schema:
+                type: "array"
+                items:
+                  $ref: '#/components/schemas/Product'
+              examples:
+                application/json:
+                  value:
+                    - id: "1234"
+                      type: "food"
+                      price: 42
+        "400":
+          description: Invalid ID supplied
+          content: {}
+  /product/{id}:
+    get:
+      summary: Find product by ID
+      description: Returns a single product
+      operationId: getProductByID
+      parameters: 
+      - name: id
+        in: path
+        description: ID of product to get
+        schema:
+          type: integer
+        required: true
+        example: 200
+      responses:
+        "200":
+          description: successful operation
+          content:
+            "application/json; charset=utf-8":
+              schema:
+                $ref: '#/components/schemas/Product'
+              examples:
+                application/json:
+                  value:
+                    id: "1234"
+                    type: "food"
+                    price: 42
+                    # name: "pizza"
+                    # version: "1.0.0"
+                    # see https://github.com/apiaryio/dredd/issues/1430 for why
+        "400":
+          description: Invalid ID supplied
+          content: {}
+        "404":
+          description: Product not found
+          content: {}
+components:
+  schemas:
+    Product:
+      type: object
+      required:
+        - id
+        - name
+        - price
+      additionalProperties: false # WARNING! without this, a consumer can add stuff that doesn't exist! See also https://bitbucket.org/atlassian/swagger-mock-validator/issues/84/test-incorrectly-passes-when-mock-expects
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        price:
+          type: number

--- a/test/e2e/fixtures/v3-pact-file.json
+++ b/test/e2e/fixtures/v3-pact-file.json
@@ -1,0 +1,70 @@
+{
+    "consumer": {
+        "name": "pactflow-example-bi-directional-consumer-nock"
+    },
+    "provider": {
+        "name": "pactflow-example-bi-directional-provider-dredd"
+    },
+    "interactions": [
+        {
+            "description": "nock_GET_/products_200",
+            "request": {
+                "method": "GET",
+                "path": "/products",
+                "body": "",
+                "query":{
+                    "max_results": ["100"]
+                }
+            },
+            "response": {
+                "status": 200,
+                "body": [
+                    {
+                        "id": "09",
+                        "type": "CREDIT_CARD",
+                        "name": "Gem Visa",
+                        "version": "v1",
+                        "price": 99.99
+                    },
+                    {
+                        "id": "10",
+                        "type": "CREDIT_CARD",
+                        "name": "28 Degrees",
+                        "version": "v1",
+                        "price": 49.49
+                    },
+                    {
+                        "id": "11",
+                        "type": "PERSONAL_LOAN",
+                        "name": "MyFlexiPay",
+                        "version": "v2",
+                        "price": 16.5
+                    }
+                ]
+            }
+        },
+        {
+            "description": "nock_GET_/product/10_200",
+            "request": {
+                "method": "GET",
+                "path": "/product/10",
+                "body": ""
+            },
+            "response": {
+                "status": 200,
+                "body": {
+                    "id": "10",
+                    "type": "CREDIT_CARD",
+                    "name": "28 Degrees",
+                    "version": "v1",
+                    "price": 49.49
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "pactSpecification": {
+            "version": "3.0.0"
+        }
+    }
+}

--- a/test/e2e/fixtures/v4-pact-file.json
+++ b/test/e2e/fixtures/v4-pact-file.json
@@ -1,0 +1,81 @@
+{
+    "consumer": {
+        "name": "pactflow-example-bi-directional-consumer-nock"
+    },
+    "provider": {
+        "name": "pactflow-example-bi-directional-provider-dredd"
+    },
+    "interactions": [
+        {
+            "type": "Synchronous/HTTP",
+            "description": "products",
+            "key": "8d1495bb",
+            "pending": false,
+            "comments": "",
+            "interactionMarkup":"",
+            "pluginConfiguration": [],
+            "request": {
+                "headers": {
+                    "Content-Type": ["image/gif"]
+                  },
+                "method": "GET",
+                "path": "/products",
+                "body": ""
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": ["image/gif"]
+                  },
+                "body": [
+                    {
+                        "id": "09",
+                        "type": "CREDIT_CARD",
+                        "name": "Gem Visa",
+                        "version": "v1",
+                        "price": 99.99
+                    },
+                    {
+                        "id": "10",
+                        "type": "CREDIT_CARD",
+                        "name": "28 Degrees",
+                        "version": "v1",
+                        "price": 49.49
+                    },
+                    {
+                        "id": "11",
+                        "type": "PERSONAL_LOAN",
+                        "name": "MyFlexiPay",
+                        "version": "v2",
+                        "price": 16.5
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Asynchronous/Messages",
+            "key": "8d1495aa",
+            "description": "product by id",
+            "request": {
+                "method": "GET",
+                "path": "/product/10",
+                "body": ""
+            },
+            "response": {
+                "status": 200,
+                "body": {
+                    "id": "10",
+                    "type": "CREDIT_CARD",
+                    "name": "28 Degrees",
+                    "version": "v1",
+                    "price": 49.49
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "pactSpecification": {
+            "version": "4.0.0"
+        }
+    }
+}

--- a/test/e2e/fixtures/v4-pact-file.json
+++ b/test/e2e/fixtures/v4-pact-file.json
@@ -12,21 +12,23 @@
             "key": "8d1495bb",
             "pending": false,
             "comments": "",
-            "interactionMarkup":"",
+            "interactionMarkup": "",
             "pluginConfiguration": [],
             "request": {
-                "headers": {
-                    "Content-Type": ["image/gif"]
-                  },
                 "method": "GET",
                 "path": "/products",
-                "body": ""
+                "body": "",
+                "query":{
+                    "max_results": ["100"]
+                }
             },
             "response": {
                 "status": 200,
                 "headers": {
-                    "Content-Type": ["image/gif"]
-                  },
+                    "Content-Type": [
+                        "application/json"
+                    ]
+                },
                 "body": [
                     {
                         "id": "09",
@@ -50,6 +52,25 @@
                         "price": 16.5
                     }
                 ]
+            }
+        },
+        {
+            "type": "Synchronous/HTTP",
+            "key": "8d1495aa",
+            "description": "product by id",
+            "request": {
+                "method": "GET",
+                "path": "/product/200"
+            },
+            "response": {
+                "status": 200,
+                "body": {
+                    "id": "10",
+                    "type": "CREDIT_CARD",
+                    "name": "28 Degrees",
+                    "version": "v1",
+                    "price": 49.49
+                }
             }
         },
         {

--- a/test/unit/pact-parser.spec.ts
+++ b/test/unit/pact-parser.spec.ts
@@ -46,7 +46,7 @@ describe('pact-parser', () => {
         expect(pact.interactions[0].requestHeaders['Content-Type'].value).toEqual('text/json')
     });
 
-    it('should filter out interactions that have a type defined other than "Synchronous/HTTP"', () => {
+    it('should filter out interactions that have a type defined other than \'Synchronous/HTTP\'', () => {
 
         const pactV4Json = {
             'consumer': {
@@ -66,7 +66,7 @@ describe('pact-parser', () => {
                 },
                 {
                     'name': 'Synchronous/HTTP defined',
-                    "type": "Synchronous/HTTP",
+                    'type': 'Synchronous/HTTP',
                     'description': 'a request to retrieve a product with existing id',
                     'request': {
                         'method': 'GET',
@@ -78,7 +78,7 @@ describe('pact-parser', () => {
                 },
                 {
                     'name': 'different type defined',
-                    "type": "Asynchronous/Messages",
+                    'type': 'Asynchronous/Messages',
                     'description': 'a request to retrieve a product with existing id',
                     'request': {
                         'method': 'GET',

--- a/test/unit/pact-parser.spec.ts
+++ b/test/unit/pact-parser.spec.ts
@@ -45,4 +45,60 @@ describe('pact-parser', () => {
         expect(pact.interactions[0].requestHeaders.Accept.value).toEqual('text/plain,application/json,text/json')
         expect(pact.interactions[0].requestHeaders['Content-Type'].value).toEqual('text/json')
     });
+
+    it('should filter out interactions that have a type defined other than "Synchronous/HTTP"', () => {
+
+        const pactV4Json = {
+            'consumer': {
+                'name': 'ExampleConsumer'
+            },
+            'interactions': [
+                {
+                    'name': 'no type defined pre pactv4 spec',
+                    'description': 'a request to retrieve a product with existing id',
+                    'request': {
+                        'method': 'GET',
+                        'path': '/products/27'
+                    },
+                    'response': {
+                        'status': 200
+                    }
+                },
+                {
+                    'name': 'Synchronous/HTTP defined',
+                    "type": "Synchronous/HTTP",
+                    'description': 'a request to retrieve a product with existing id',
+                    'request': {
+                        'method': 'GET',
+                        'path': '/products/27'
+                    },
+                    'response': {
+                        'status': 200
+                    }
+                },
+                {
+                    'name': 'different type defined',
+                    "type": "Asynchronous/Messages",
+                    'description': 'a request to retrieve a product with existing id',
+                    'request': {
+                        'method': 'GET',
+                        'path': '/products/27'
+                    },
+                    'response': {
+                        'status': 200
+                    }
+                }
+            ],
+            'provider': {
+                'name': 'ExampleProvider'
+            }
+        }
+
+
+        const resolvedPact = validateAndResolvePact(pactV4Json, '../../pact_examples/pact.json');
+
+
+        const pact = pactParser.parse(resolvedPact, 'sdfsdf')
+        expect(pact.interactions.length).toEqual(2)
+    });
 });


### PR DESCRIPTION
This PR introduces support for the Pact V4 specification. Specifically this will allow pact interactions with "type": "Synchronous/HTTP" to be validated against the OAS spec, and no other features of v4 should cause the validation to break.

The main functionality change is to filter out interactions with a type other than "Synchronous/HTTP" as other types are not supported in BDC flow.

I have added some end to end tests for v3 and v4 pact files. If any issues with compatibility that I've missed arise this should make it easier to reproduce and fix.

- [x] Added filtering for interaction types
- [x] test for filtering
- [x] general tests for v4 examples