### PR TITLE
feat: Respect request and response content-types

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,3 +1,3 @@
 node --version
-npm install
-npm test
+yarn install
+yarn test

--- a/lib/swagger-mock-validator/spec-parser/openapi3/openapi3-parser/parse-responses.ts
+++ b/lib/swagger-mock-validator/spec-parser/openapi3/openapi3-parser/parse-responses.ts
@@ -3,7 +3,7 @@ import {ParsedSpecOperation, ParsedSpecResponse, ParsedSpecResponses} from '../.
 import {Openapi3Schema, Operation, Reference, Response} from '../openapi3';
 import {dereferenceComponent} from './dereference-component';
 import {getContentMimeTypes} from './get-content-mime-types';
-import {getContentSchema} from './get-content-schema';
+import {getDefaultContentSchema, getContentSchemasByContentType} from './get-content-schema';
 import {parseResponseHeaders} from './parse-response-headers';
 
 interface ParseResponseOptions {
@@ -22,12 +22,13 @@ const parseResponse = (
     {response, parentOperation, responseLocation, spec}: ParseResponseOptions
 ): ParsedSpecResponse => {
     const dereferencedResponse = dereferenceComponent(response, spec);
-    const {schema, mediaType} = getContentSchema(dereferencedResponse.content, spec);
+    const {schema, mediaType} = getDefaultContentSchema(dereferencedResponse.content, spec);
+    const schemasByContentType = getContentSchemasByContentType(dereferencedResponse.content, spec);
 
     return {
-        getFromSchema: (pathToGet: string) => {
+        getFromSchema: (pathToGet, actualMediaType) => {
             return {
-                location: `${responseLocation}.content.${mediaType}.schema.${pathToGet}`,
+                location: `${responseLocation}.content.${actualMediaType || mediaType}.schema.${pathToGet}`,
                 parentOperation,
                 value: _.get(schema, pathToGet)
             };
@@ -42,6 +43,7 @@ const parseResponse = (
             value: getContentMimeTypes(dereferencedResponse.content)
         },
         schema,
+        schemasByContentType,
         value: response
     };
 };

--- a/lib/swagger-mock-validator/spec-parser/parsed-spec.d.ts
+++ b/lib/swagger-mock-validator/spec-parser/parsed-spec.d.ts
@@ -99,8 +99,9 @@ interface ParsedSpecJsonSchemaProperties {
 
 export interface ParsedSpecResponse extends ParsedSpecValue<any> {
     headers: ParsedSpecParameterCollection;
-    getFromSchema: (pathToGet: string) => ParsedSpecValue<any>;
+    getFromSchema: (pathToGet: string, mediaType: string) => ParsedSpecValue<any>;
     schema?: ParsedSpecJsonSchema;
+    schemasByContentType?: Record<string, ParsedSpecJsonSchema>;
     produces: ParsedSpecValue<string[]>;
 }
 
@@ -114,10 +115,11 @@ export interface ParsedSpecParameter extends ParsedSpecValue<any> {
 }
 
 export interface ParsedSpecBody {
-    getFromSchema: (pathToGet: string) => ParsedSpecValue<any>;
+    getFromSchema: (pathToGet: string, mediaType: string) => ParsedSpecValue<any>;
     name: string;
     required?: boolean;
     schema: ParsedSpecJsonSchema;
+    schemasByContentType?: Record<string, ParsedSpecJsonSchema>;
 }
 
 export interface ParsedSpecValue<T> {

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
@@ -60,7 +60,7 @@ export const validateParsedMockRequestBody = (parsedMockInteraction: ParsedMockI
     if (shouldSkipValidation(parsedMockInteraction, parsedSpecOperation)) {
         // this is temporary code to identify passing validations that should've failed
         // tslint:disable:cyclomatic-complexity
-        if (isNotSupportedMediaType(parsedSpecOperation)) {
+        if (process.env.DEBUG_CONTENT_TYPE_ISSUE && isNotSupportedMediaType(parsedSpecOperation)) {
             const debugValidation = (validation: any) => {
                 console.error(
                     JSON.stringify({

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
@@ -59,18 +59,19 @@ export const validateParsedMockRequestBody = (parsedMockInteraction: ParsedMockI
                                               parsedSpecOperation: ParsedSpecOperation) => {
     if (shouldSkipValidation(parsedMockInteraction, parsedSpecOperation)) {
         // this is temporary code to identify passing validations that should've failed
+        // tslint:disable:cyclomatic-complexity
         if (isNotSupportedMediaType(parsedSpecOperation)) {
             const debugValidation = (validation: any) => {
                 console.error(
                     JSON.stringify({
-                        message: "Passing validation that should've failed due to unsupported media type",
+                        message: 'Passing validation that should\'ve failed due to unsupported media type',
                         pact_request: {
-                          'content-type': parsedMockInteraction.requestHeaders['content-type']?.value,
+                          'content-type': parsedMockInteraction.requestHeaders['content-type']?.value
                         },
                         oas_consumes: {
-                          'content-type': parsedSpecOperation.consumes.value,
+                          'content-type': parsedSpecOperation.consumes.value
                         },
-                        validation,
+                        validation
                     })
                 );
             };
@@ -93,6 +94,7 @@ export const validateParsedMockRequestBody = (parsedMockInteraction: ParsedMockI
                 ]);
             }
         }
+        // tslint:enable:cyclomatic-complexity
 
         return [];
     }

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import {ParsedMockInteraction} from '../mock-parser/parsed-mock';
 import {result} from '../result';
 import {ParsedSpecBody, ParsedSpecOperation} from '../spec-parser/parsed-spec';
+import {isMediaTypeSupported} from './content-negotiation';
 import {validateJson} from './validate-json';
 
 const validateRequestBodyAgainstSchema = (
@@ -44,14 +45,55 @@ const specAndMockHaveNoBody = (parsedMockInteraction: ParsedMockInteraction,
                                parsedSpecOperation: ParsedSpecOperation) =>
     !parsedSpecOperation.requestBodyParameter && !parsedMockInteraction.requestBody.value;
 
+const isNotSupportedMediaType = (parsedSpecOperation: ParsedSpecOperation) =>
+    parsedSpecOperation.consumes.value.length > 0 &&
+    !isMediaTypeSupported('application/json', parsedSpecOperation.consumes.value);
+
 const shouldSkipValidation = (parsedMockInteraction: ParsedMockInteraction,
                               parsedSpecOperation: ParsedSpecOperation) =>
+    isNotSupportedMediaType(parsedSpecOperation) ||
     specAndMockHaveNoBody(parsedMockInteraction, parsedSpecOperation) ||
     isOptionalRequestBodyMissing(parsedMockInteraction, parsedSpecOperation);
 
 export const validateParsedMockRequestBody = (parsedMockInteraction: ParsedMockInteraction,
                                               parsedSpecOperation: ParsedSpecOperation) => {
     if (shouldSkipValidation(parsedMockInteraction, parsedSpecOperation)) {
+        // this is temporary code to identify passing validations that should've failed
+        if (isNotSupportedMediaType(parsedSpecOperation)) {
+            const debugValidation = (validation: any) => {
+                console.error(
+                    JSON.stringify({
+                        message: "Passing validation that should've failed due to unsupported media type",
+                        pact_request: {
+                          'content-type': parsedMockInteraction.requestHeaders['content-type']?.value,
+                        },
+                        oas_consumes: {
+                          'content-type': parsedSpecOperation.consumes.value,
+                        },
+                        validation,
+                    })
+                );
+            };
+            if (parsedSpecOperation.requestBodyParameter) {
+                debugValidation(
+                    validateRequestBodyAgainstSchema(
+                        parsedMockInteraction,
+                        parsedSpecOperation
+                    )
+                );
+            } else {
+                debugValidation([
+                    result.build({
+                        code: 'request.body.unknown',
+                        message: 'No schema found for request body',
+                        mockSegment: parsedMockInteraction.requestBody,
+                        source: 'spec-mock-validation',
+                        specSegment: parsedSpecOperation
+                    })
+                ]);
+            }
+        }
+
         return [];
     }
 

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
@@ -79,12 +79,19 @@ export const validateParsedMockResponseBody = (
     ];
   }
 
+  // start with a default schema
   let responseBodyToValidate: ParsedSpecJsonSchema = parsedSpecResponse.schema;
+
+  // switch schema based on content-type
+  const contentType = parsedMockInteraction.responseHeaders['content-type']?.value;
+  if (contentType && parsedSpecResponse.schemasByContentType && parsedSpecResponse.schemasByContentType[contentType]) {
+    responseBodyToValidate = parsedSpecResponse.schemasByContentType[contentType];
+  }
 
   // tslint:disable:cyclomatic-complexity
   if (!opts.additionalPropertiesInResponse) {
     responseBodyToValidate = setAdditionalPropertiesToFalseInSchema(
-      parsedSpecResponse.schema
+      responseBodyToValidate
     );
   }
   if (!opts.requiredPropertiesInResponse) {
@@ -112,7 +119,8 @@ export const validateParsedMockResponseBody = (
       mockSegment: parsedMockInteraction.getResponseBodyPath(error.dataPath),
       source: 'spec-mock-validation',
       specSegment: parsedSpecResponse.getFromSchema(
-        error.schemaPath.replace(/\//g, '.').substring(2)
+        error.schemaPath.replace(/\//g, '.').substring(2),
+        contentType
       )
     });
   });

--- a/test/e2e/fixtures/openapi3-provider.yaml
+++ b/test/e2e/fixtures/openapi3-provider.yaml
@@ -210,6 +210,37 @@ paths:
                 properties:
                   id:
                     type: number
+  /response-content-type-vnd-api-json-test:
+    post:
+      requestBody:
+        required: true
+        content:
+          'application/vnd.api+json':
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: "string"
+                    type:
+                      type: "string"
+      responses:
+        '200':
+          description: The result
+          content:
+            'application/vnd.api+json':
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: "string"
+                      type:
+                        type: "string"
   /authorization-test:
     get:
       responses:

--- a/test/e2e/fixtures/pact-working-consumer.json
+++ b/test/e2e/fixtures/pact-working-consumer.json
@@ -285,6 +285,33 @@
             "status": 200
         }
     }, {
+        "description": "response content type header (vnd.api+json) valid test",
+        "request": {
+            "headers": {
+                "content-type": "application/vnd.api+json"
+            },
+            "method": "post",
+            "path": "/response-content-type-vnd-api-json-test",
+            "body": {
+                "data": {
+                    "id": "id",
+                    "type": "type"
+                }
+            }
+        },
+        "response": {
+            "body": {
+                "data": {
+                  "id": "1",
+                  "type": "test"
+                }
+            },
+            "headers": {
+                "Content-Type": "application/vnd.api+json"
+            },
+            "status": 200
+        }
+    }, {
         "description": "authorization valid test",
         "request": {
             "headers": {

--- a/test/e2e/fixtures/swagger-provider.json
+++ b/test/e2e/fixtures/swagger-provider.json
@@ -206,6 +206,56 @@
                 }
             }
         },
+        "/response-content-type-vnd-api-json-test": {
+            "post": {
+                "consumes": ["application/vnd.api+json"],
+                "parameters": [{
+                    "name": "body",
+                    "in": "body",
+                    "required": true,
+                      "schema": {
+                          "type": "object",
+                          "properties": {
+                              "data": {
+                                  "type": "object",
+                                  "properties": {
+                                      "id": {
+                                          "type": "string"
+                                      },
+                                      "type": {
+                                          "type": "string"
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                }],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The result",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/authorization-test": {
             "get": {
                 "responses": {

--- a/test/unit/openapi3/openapi3.spec.ts
+++ b/test/unit/openapi3/openapi3.spec.ts
@@ -532,7 +532,7 @@ describe('openapi3/parser', () => {
         it('should return error if pact not compatible with application/json request with charset', async () => {
             const pactFile = pactBuilder
                 .withInteraction(defaultInteractionBuilder
-                    .withRequestHeader('content-type', 'application/json; charset=UTF-8')
+                    .withRequestHeader('content-type', 'application/json;charset=utf-8')
                     .withRequestBody(true))
                 .build();
 


### PR DESCRIPTION
Both request and response bodies can have different schemas based on its content-type. Prior to this, we default to using the schema associated with `application/json` as *the* schema. This is incorrect when there is a vendor extension, such as `application/vnd.api+json`, whether that is the only schema or alongside another.

This PR dynamically switches the relevant schema based on its content-type.