### PR TITLE
feat: handle more varieties of json

### DIFF
--- a/lib/swagger-mock-validator/spec-parser/parsed-spec.d.ts
+++ b/lib/swagger-mock-validator/spec-parser/parsed-spec.d.ts
@@ -97,11 +97,15 @@ interface ParsedSpecJsonSchemaProperties {
     [name: string]: ParsedSpecJsonSchema;
 }
 
+export interface GetContentSchemaResult {
+    schema: ParsedSpecJsonSchema;
+    mediaType: string;
+}
+
 export interface ParsedSpecResponse extends ParsedSpecValue<any> {
     headers: ParsedSpecParameterCollection;
-    getFromSchema: (pathToGet: string, mediaType: string) => ParsedSpecValue<any>;
-    schema?: ParsedSpecJsonSchema;
-    schemasByContentType?: Record<string, ParsedSpecJsonSchema>;
+    getFromSchema: (pathToGet: string, schema: ParsedSpecJsonSchema, mediaType: string) => ParsedSpecValue<any>;
+    schemaByContentType: (mediaType: string) => GetContentSchemaResult | undefined;
     produces: ParsedSpecValue<string[]>;
 }
 
@@ -115,11 +119,10 @@ export interface ParsedSpecParameter extends ParsedSpecValue<any> {
 }
 
 export interface ParsedSpecBody {
-    getFromSchema: (pathToGet: string, mediaType: string) => ParsedSpecValue<any>;
+    getFromSchema: (pathToGet: string, schema: ParsedSpecJsonSchema, mediaType: string) => ParsedSpecValue<any>;
+    schemaByContentType: (mediaType: string) => GetContentSchemaResult | undefined;
     name: string;
     required?: boolean;
-    schema: ParsedSpecJsonSchema;
-    schemasByContentType?: Record<string, ParsedSpecJsonSchema>;
 }
 
 export interface ParsedSpecValue<T> {

--- a/lib/swagger-mock-validator/spec-parser/swagger2/swagger2-parser.ts
+++ b/lib/swagger-mock-validator/spec-parser/swagger2/swagger2-parser.ts
@@ -41,15 +41,10 @@ const toParsedSpecValue = (
     value: parameter
 }));
 
-const addDefinitionsToSchema = (
-    schema: Swagger2JsonSchema | undefined, spec: Swagger2
-): Swagger2JsonSchema | undefined => {
-    if (schema) {
-        const modifiedSchema = _.cloneDeep(schema);
-        modifiedSchema.definitions = spec.definitions;
-        return modifiedSchema;
-    }
-    return undefined;
+const addDefinitionsToSchema = (schema: Swagger2JsonSchema, spec: Swagger2): Swagger2JsonSchema => {
+    const modifiedSchema = _.cloneDeep(schema);
+    modifiedSchema.definitions = spec.definitions;
+    return modifiedSchema;
 };
 
 const mergePathAndOperationParameters = (
@@ -153,19 +148,27 @@ const parseResponses = (
 
     _.each(responses, (response, responseStatus) => {
         const responseLocation = `${parsedResponses.location}.${responseStatus}`;
-        const originalSchema = response.schema;
 
         parsedResponses[responseStatus as any] = {
-            getFromSchema: (pathToGet) => ({
-                location: `${responseLocation}.schema.${pathToGet}`,
+            getFromSchema: (path, schema) => ({
+                location: `${responseLocation}.schema.${path}`,
                 parentOperation,
-                value: _.get(originalSchema, pathToGet)
+                value: _.get(schema, path)
             }),
             headers: parseResponseHeaders(response.headers, responseLocation, parentOperation),
             location: responseLocation,
             parentOperation,
             produces,
-            schema: addDefinitionsToSchema(response.schema, specJson),
+            schemaByContentType: (mediaType: string) => {
+                if (!response.schema) {
+                    return undefined;
+                }
+
+                return {
+                    schema: addDefinitionsToSchema(response.schema, specJson),
+                    mediaType
+                }
+            },
             value: response
         };
     });
@@ -189,18 +192,27 @@ const toRequestBodyParameter = (
             modifiedSchema.definitions = definitions;
 
             return {
-                getFromSchema: (pathToGet: string): ParsedSpecValue<any> => ({
-                    location: `${parameter.location}.schema.${pathToGet}`,
+                getFromSchema: (path, schema,  _mediaType) => ({
+                    location: `${parameter.location}.schema.${path}`,
                     parentOperation: parameter.parentOperation,
-                    value: _.get(parameter.value.schema, pathToGet)
+                    value: _.get(schema, path)
                 }),
                 location: parameter.location,
                 name: parameter.value.name,
                 parentOperation: parameter.parentOperation,
                 required: parameter.value.required,
-                schema: modifiedSchema,
+                schemaByContentType: (mediaType: string) => {
+                  if (!parameter.value.schema) {
+                      return undefined;
+                  }
+
+                  return {
+                      schema: modifiedSchema,
+                      mediaType
+                  }
+                },
                 value: parameter.value
-            };
+            } as ParsedSpecBody;
         })
         .first();
 

--- a/lib/swagger-mock-validator/validate-spec-and-mock/content-negotiation.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/content-negotiation.ts
@@ -16,7 +16,7 @@ const parseMediaType = (mediaType: string): { type: string, subtype: string } =>
     return {type, subtype};
 };
 
-const areMediaTypesCompatible = (actualMediaType: string, supportedMediaType: string): boolean => {
+export const areMediaTypesCompatible = (actualMediaType: string, supportedMediaType: string): boolean => {
     const parsedActualMediaType = parseMediaType(actualMediaType);
     const parsedSupportedMediaType = parseMediaType(supportedMediaType);
 
@@ -24,7 +24,7 @@ const areMediaTypesCompatible = (actualMediaType: string, supportedMediaType: st
         areTypeFragmentsCompatible(parsedActualMediaType.subtype, parsedSupportedMediaType.subtype);
 };
 
-const normalizeMediaType = (mediaType: string): string => {
+export const normalizeMediaType = (mediaType: string): string => {
     return mediaType
         .split(PARAMETER_SEPARATOR)[0]
         .toLowerCase()
@@ -38,5 +38,12 @@ export const isMediaTypeSupported = (actualMediaType: string, supportedMediaType
         const normalizedSupportedMediaType = normalizeMediaType(supportedMediaType);
 
         return areMediaTypesCompatible(normalizedActualMediaType, normalizedSupportedMediaType);
+    });
+};
+
+export const isTypesOfJson = (supportedMediaTypes: string[]): boolean => {
+    return supportedMediaTypes.some((supportedMediaType) => {
+        const mediaType = normalizeMediaType(supportedMediaType);
+        return mediaType.startsWith("application/") && mediaType.endsWith("json") || mediaType === "*/*";
     });
 };

--- a/lib/swagger-mock-validator/validate-spec-and-mock/content-negotiation.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/content-negotiation.ts
@@ -44,6 +44,6 @@ export const isMediaTypeSupported = (actualMediaType: string, supportedMediaType
 export const isTypesOfJson = (supportedMediaTypes: string[]): boolean => {
     return supportedMediaTypes.some((supportedMediaType) => {
         const mediaType = normalizeMediaType(supportedMediaType);
-        return mediaType.startsWith("application/") && mediaType.endsWith("json") || mediaType === "*/*";
+        return mediaType.startsWith('application/') && mediaType.endsWith('json') || mediaType === '*/*';
     });
 };

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import {ParsedMockInteraction} from '../mock-parser/parsed-mock';
 import {result} from '../result';
 import {ParsedSpecBody, ParsedSpecOperation} from '../spec-parser/parsed-spec';
-import {isMediaTypeSupported} from './content-negotiation';
+import {isTypesOfJson} from './content-negotiation';
 import {validateJson} from './validate-json';
 
 const validateRequestBodyAgainstSchema = (
@@ -12,16 +12,26 @@ const validateRequestBodyAgainstSchema = (
     const parsedMockRequestBody = parsedMockInteraction.requestBody;
     const parsedSpecRequestBody = parsedSpecOperation.requestBodyParameter as ParsedSpecBody;
 
-    // start with a default schema
-    let schema = parsedSpecRequestBody.schema
+    const expectedMediaType = parsedMockInteraction.requestHeaders['content-type']?.value;
+    const schemaForMediaType = parsedSpecRequestBody.schemaByContentType(expectedMediaType);
 
-    // switch schema based on content-type
-    const contentType = parsedMockInteraction.requestHeaders['content-type']?.value;
-    if (contentType && parsedSpecRequestBody.schemasByContentType && parsedSpecRequestBody.schemasByContentType[contentType]) {
-      schema = parsedSpecRequestBody.schemasByContentType[contentType]
+    if (!schemaForMediaType) {
+      // This is redundant: 'request.content-type.incompatible' would have already been returned
+      // But we keep it here as defensive programming
+      return [
+          result.build({
+              code: 'request.body.unknown',
+              message: 'No matching schema found for request body',
+              mockSegment: parsedMockInteraction.requestBody,
+              source: 'spec-mock-validation',
+              specSegment: parsedSpecOperation
+          })
+      ];
     }
 
-    const validationErrors = validateJson(schema, parsedMockRequestBody.value);
+    const { schema, mediaType } = schemaForMediaType;
+
+    const validationErrors = validateJson(schemaForMediaType.schema, parsedMockRequestBody.value);
 
     return _.map(validationErrors, (error) => result.build({
         code: 'request.body.incompatible',
@@ -31,7 +41,8 @@ const validateRequestBodyAgainstSchema = (
         source: 'spec-mock-validation',
         specSegment: parsedSpecRequestBody.getFromSchema(
             error.schemaPath.replace(/\//g, '.').substring(2),
-            contentType
+            schema,
+            mediaType
         )
     }));
 };
@@ -47,7 +58,7 @@ const specAndMockHaveNoBody = (parsedMockInteraction: ParsedMockInteraction,
 
 const isNotSupportedMediaType = (parsedSpecOperation: ParsedSpecOperation) =>
     parsedSpecOperation.consumes.value.length > 0 &&
-    !isMediaTypeSupported('application/json', parsedSpecOperation.consumes.value);
+    !isTypesOfJson(parsedSpecOperation.consumes.value);
 
 const shouldSkipValidation = (parsedMockInteraction: ParsedMockInteraction,
                               parsedSpecOperation: ParsedSpecOperation) =>
@@ -58,44 +69,6 @@ const shouldSkipValidation = (parsedMockInteraction: ParsedMockInteraction,
 export const validateParsedMockRequestBody = (parsedMockInteraction: ParsedMockInteraction,
                                               parsedSpecOperation: ParsedSpecOperation) => {
     if (shouldSkipValidation(parsedMockInteraction, parsedSpecOperation)) {
-        // this is temporary code to identify passing validations that should've failed
-        // tslint:disable:cyclomatic-complexity
-        if (process.env.DEBUG_CONTENT_TYPE_ISSUE && isNotSupportedMediaType(parsedSpecOperation)) {
-            const debugValidation = (validation: any) => {
-                console.error(
-                    JSON.stringify({
-                        message: 'Passing validation that should\'ve failed due to unsupported media type',
-                        pact_request: {
-                          'content-type': parsedMockInteraction.requestHeaders['content-type']?.value
-                        },
-                        oas_consumes: {
-                          'content-type': parsedSpecOperation.consumes.value
-                        },
-                        validation
-                    })
-                );
-            };
-            if (parsedSpecOperation.requestBodyParameter) {
-                debugValidation(
-                    validateRequestBodyAgainstSchema(
-                        parsedMockInteraction,
-                        parsedSpecOperation
-                    )
-                );
-            } else {
-                debugValidation([
-                    result.build({
-                        code: 'request.body.unknown',
-                        message: 'No schema found for request body',
-                        mockSegment: parsedMockInteraction.requestBody,
-                        source: 'spec-mock-validation',
-                        specSegment: parsedSpecOperation
-                    })
-                ]);
-            }
-        }
-        // tslint:enable:cyclomatic-complexity
-
         return [];
     }
 

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
@@ -16,8 +16,6 @@ const validateRequestBodyAgainstSchema = (
     const schemaForMediaType = parsedSpecRequestBody.schemaByContentType(expectedMediaType);
 
     if (!schemaForMediaType) {
-      // This is redundant: 'request.content-type.incompatible' would have already been returned
-      // But we keep it here as defensive programming
       return [
           result.build({
               code: 'request.body.unknown',

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
@@ -72,8 +72,6 @@ export const validateParsedMockResponseBody = (
   const schemaForMediaType = parsedSpecResponse.schemaByContentType(expectedMediaType);
 
   if (!schemaForMediaType) {
-    // This is redundant: 'request.accept.incompatible' would have already been returned
-    // But we keep it here as defensive programming
     return [
       result.build({
         code: 'response.body.unknown',

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
@@ -68,7 +68,7 @@ export const validateParsedMockResponseBody = (
     return [];
   }
 
-  const expectedMediaType = parsedMockInteraction.requestHeaders['accept']?.value;
+  const expectedMediaType = parsedMockInteraction.requestHeaders.accept?.value;
   const schemaForMediaType = parsedSpecResponse.schemaByContentType(expectedMediaType);
 
   if (!schemaForMediaType) {

--- a/test/unit/openapi3/openapi3.spec.ts
+++ b/test/unit/openapi3/openapi3.spec.ts
@@ -597,8 +597,6 @@ describe('openapi3/parser', () => {
 
             const result = await swaggerMockValidatorLoader.invoke(specFile, pactFile);
 
-            // console.log(JSON.stringify(result, null, 4));
-
             expect(result).toContainErrors([{
                 code: 'request.body.incompatible',
                 message: 'Request body is incompatible with the request body schema in the spec file: should be boolean',

--- a/test/unit/openapi3/openapi3.spec.ts
+++ b/test/unit/openapi3/openapi3.spec.ts
@@ -508,7 +508,7 @@ describe('openapi3/parser', () => {
             }]);
         });
 
-        it('should pass when request body has an unsupported mimetype (unsupported feature)', async () => {
+        it('should pass when request body is not a type of json', async () => {
             const pactFile = pactBuilder
                 .withInteraction(defaultInteractionBuilder
                     .withRequestHeader('Content-Type', 'application/xml')
@@ -563,6 +563,74 @@ describe('openapi3/parser', () => {
                 specDetails: {
                     location: `[root].paths.${defaultPath}.get.requestBody.content.` +
                         'application/json;charset=utf-8.schema.type',
+                    pathMethod: 'get',
+                    pathName: defaultPath,
+                    specFile: 'spec.json',
+                    value: 'number'
+                },
+                type: 'error'
+            }]);
+        });
+
+        it('should match compatible request content-types', async () => {
+            const pactFile = pactBuilder
+                .withInteraction(defaultInteractionBuilder
+                    .withRequestHeader('content-type', 'application/boolean+json; charset=utf-8')
+                    .withRequestBody([]))
+                .withInteraction(defaultInteractionBuilder
+                    .withRequestHeader('content-type', 'application/number+json; charset=utf-8')
+                    .withRequestBody([]))
+                .build();
+
+            const operationBuilder = openApi3OperationBuilder
+                .withRequestBody(openApi3RequestBodyBuilder
+                    .withContent(openApi3ContentBuilder
+                        .withMimeTypeContent('application/boolean+json', openApi3SchemaBuilder.withTypeBoolean())
+                        .withMimeTypeContent('application/number+json', openApi3SchemaBuilder.withTypeNumber())
+                    )
+                )
+                .withResponse(200, openApi3ResponseBuilder);
+
+            const specFile = openApi3Builder
+                .withPath(defaultPath, openApi3PathItemBuilder.withGetOperation(operationBuilder))
+                .build();
+
+            const result = await swaggerMockValidatorLoader.invoke(specFile, pactFile);
+
+            // console.log(JSON.stringify(result, null, 4));
+
+            expect(result).toContainErrors([{
+                code: 'request.body.incompatible',
+                message: 'Request body is incompatible with the request body schema in the spec file: should be boolean',
+                mockDetails: {
+                    interactionDescription: defaultInteractionDescription,
+                    interactionState: '[none]',
+                    location: '[root].interactions[0].request.body',
+                    mockFile: 'pact.json',
+                    value: []
+                },
+                source: 'spec-mock-validation',
+                specDetails: {
+                    location: `[root].paths.${defaultPath}.get.requestBody.content.application/boolean+json.schema.type`,
+                    pathMethod: 'get',
+                    pathName: defaultPath,
+                    specFile: 'spec.json',
+                    value: 'boolean'
+                },
+                type: 'error'
+            }, {
+                code: 'request.body.incompatible',
+                message: 'Request body is incompatible with the request body schema in the spec file: should be number',
+                mockDetails: {
+                    interactionDescription: defaultInteractionDescription,
+                    interactionState: '[none]',
+                    location: '[root].interactions[1].request.body',
+                    mockFile: 'pact.json',
+                    value: []
+                },
+                source: 'spec-mock-validation',
+                specDetails: {
+                    location: `[root].paths.${defaultPath}.get.requestBody.content.application/number+json.schema.type`,
                     pathMethod: 'get',
                     pathName: defaultPath,
                     specFile: 'spec.json',
@@ -1253,7 +1321,7 @@ describe('openapi3/parser', () => {
             }]);
         });
 
-        it('should pass when response body has an unsupported mime type (unsupported feature)', async () => {
+        it('should pass when response body is not a type of json', async () => {
             const pactFile = pactBuilder
                 .withInteraction(defaultInteractionBuilder
                     .withResponseHeader('Content-Type', 'application/xml')
@@ -1310,6 +1378,71 @@ describe('openapi3/parser', () => {
                     location:
                         `[root].paths.${defaultPath}.get.responses.200.content.` +
                         'application/json;charset=utf-8.schema.type',
+                    pathMethod: 'get',
+                    pathName: defaultPath,
+                    specFile: 'spec.json',
+                    value: 'number'
+                },
+                type: 'error'
+            }]);
+        });
+
+        it('should match compatible response content-types', async () => {
+            const pactFile = pactBuilder
+                .withInteraction(defaultInteractionBuilder
+                    .withRequestHeader('accept', 'application/boolean+json; charset=UTF-8')
+                    .withResponseBody([]))
+                .withInteraction(defaultInteractionBuilder
+                    .withRequestHeader('accept', 'application/number+json; charset=UTF-8')
+                    .withResponseBody([]))
+                .build();
+
+            const operationBuilder = openApi3OperationBuilder
+                .withResponse(200, openApi3ResponseBuilder
+                    .withContent(openApi3ContentBuilder
+                        .withMimeTypeContent('application/boolean+json', openApi3SchemaBuilder.withTypeBoolean())
+                        .withMimeTypeContent('application/number+json', openApi3SchemaBuilder.withTypeNumber())
+                    )
+                );
+
+            const specFile = openApi3Builder
+                .withPath(defaultPath, openApi3PathItemBuilder.withGetOperation(operationBuilder))
+                .build();
+
+            const result = await swaggerMockValidatorLoader.invoke(specFile, pactFile);
+
+            expect(result).toContainErrors([{
+                code: 'response.body.incompatible',
+                message: 'Response body is incompatible with the response body schema in the spec file: should be boolean',
+                mockDetails: {
+                    interactionDescription: defaultInteractionDescription,
+                    interactionState: '[none]',
+                    location: '[root].interactions[0].response.body',
+                    mockFile: 'pact.json',
+                    value: []
+                },
+                source: 'spec-mock-validation',
+                specDetails: {
+                    location: `[root].paths.${defaultPath}.get.responses.200.content.application/boolean+json.schema.type`,
+                    pathMethod: 'get',
+                    pathName: defaultPath,
+                    specFile: 'spec.json',
+                    value: 'boolean'
+                },
+                type: 'error'
+            }, {
+                code: 'response.body.incompatible',
+                message: 'Response body is incompatible with the response body schema in the spec file: should be number',
+                mockDetails: {
+                    interactionDescription: defaultInteractionDescription,
+                    interactionState: '[none]',
+                    location: '[root].interactions[1].response.body',
+                    mockFile: 'pact.json',
+                    value: []
+                },
+                source: 'spec-mock-validation',
+                specDetails: {
+                    location: `[root].paths.${defaultPath}.get.responses.200.content.application/number+json.schema.type`,
                     pathMethod: 'get',
                     pathName: defaultPath,
                     specFile: 'spec.json',


### PR DESCRIPTION
This builds upon https://github.com/pactflow/swagger-mock-validator/pull/22 and supports more content-negotiation.

I've removed the logging, because I now think it is unnecessary, and added more complexity that doesn't even make sense anymore.

Once this goes into production, some previously passing validations may now fail because we incorrectly skipped validation before.

Have a look at the new specs, you can see the content-negotiation happening.