### PR TITLE
feat: parse pact-v4 request/response bodies

### DIFF
--- a/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
@@ -1,8 +1,6 @@
 import _ from 'lodash';
 import querystring from 'querystring';
-import {
-    MultiCollectionFormatSeparator
-} from '../../types';
+import { MultiCollectionFormatSeparator } from '../../types';
 import { ParsedMock, ParsedMockInteraction, ParsedMockValueCollection } from '../parsed-mock';
 import { Pact, PactInteraction, PactInteractionHeaders, PactV1RequestQuery, PactV3RequestQuery } from './pact';
 
@@ -12,7 +10,7 @@ const parseRequestPathSegments = (requestPath: string, parentInteraction: Parsed
         .map((requestPathSegment) => ({
             location: `${parentInteraction.location}.request.path`,
             parentInteraction,
-            value: requestPathSegment
+            value: requestPathSegment,
         }))
         .value();
 
@@ -27,7 +25,7 @@ const parseValues = (
             result[name] = {
                 location: `${location}.${name}`,
                 parentInteraction,
-                value
+                value,
             };
             return result;
         },
@@ -35,140 +33,187 @@ const parseValues = (
     );
 };
 
-const parseHeaders = (
-    headers: any | undefined,
-    location: string,
-    parentInteraction: ParsedMockInteraction
-) => {
+const parseHeaders = (headers: any | undefined, location: string, parentInteraction: ParsedMockInteraction) => {
     for (const key in headers) {
         if (typeof headers[key] !== 'string') {
-            headers[key] = headers[key].toString()
+            headers[key] = headers[key].toString();
         }
     }
-    return parseValues(
-        headers, location, parentInteraction
-    );
-}
+    return parseValues(headers, location, parentInteraction);
+};
 
 const isPactV1RequestQuery = (query: PactV1RequestQuery | PactV3RequestQuery): query is PactV1RequestQuery =>
-    typeof query === 'string'
+    typeof query === 'string';
 
-const parseAsPactV1RequestQuery = (requestQuery: PactV1RequestQuery): { [name: string]: string } => {
+const parseAsPactV1RequestQuery = (requestQuery: PactV1RequestQuery = ''): { [name: string]: string } => {
     const parsedQueryAsStringsOrArrayOfStrings = querystring.parse(requestQuery);
     const separator: MultiCollectionFormatSeparator = '[multi-array-separator]';
 
-    return Object.keys(parsedQueryAsStringsOrArrayOfStrings)
-        .reduce<{ [name: string]: string }>((accumulator, queryName) => {
+    return Object.keys(parsedQueryAsStringsOrArrayOfStrings).reduce<{ [name: string]: string }>(
+        (accumulator, queryName) => {
             const queryValue = parsedQueryAsStringsOrArrayOfStrings[queryName] || '';
-            accumulator[queryName] = (queryValue instanceof Array) ? queryValue.join(separator) : queryValue;
+            accumulator[queryName] = queryValue instanceof Array ? queryValue.join(separator) : queryValue;
             return accumulator;
-        }, {});
+        },
+        {}
+    );
 };
 
-const parseAsPactV3RequestQuery = (requestQuery: PactV3RequestQuery): { [name: string]: string } => {
+const parseAsPactV3RequestQuery = (requestQuery: PactV3RequestQuery = {}): { [name: string]: string } => {
     const separator: MultiCollectionFormatSeparator = '[multi-array-separator]';
-    return Object.keys(requestQuery)
-        .reduce<{ [name: string]: string }>((accumulator, queryName) => {
-            accumulator[queryName] = requestQuery[queryName].join(separator);
-            return accumulator;
-        }, {});
+    return Object.keys(requestQuery).reduce<{ [name: string]: string }>((accumulator, queryName) => {
+        accumulator[queryName] = requestQuery[queryName].join(separator);
+        return accumulator;
+    }, {});
 };
 
+// Instead of relying on version number, it is more resilient to detect the capability
 const parseRequestQuery = (
     requestQuery: PactV1RequestQuery | PactV3RequestQuery | undefined
 ): { [name: string]: string } => {
-    requestQuery = requestQuery || ''
+    requestQuery = requestQuery || '';
 
     return isPactV1RequestQuery(requestQuery)
         ? parseAsPactV1RequestQuery(requestQuery)
-        : parseAsPactV3RequestQuery(requestQuery)
+        : parseAsPactV3RequestQuery(requestQuery);
 };
 
-const parseInteraction = (
-    interaction: PactInteraction, interactionIndex: number, mockPathOrUrl: string
-) => {
-    const parsedInteraction = {
-        description: interaction.description,
-        location: `[root].interactions[${interactionIndex}]`,
-        mockFile: mockPathOrUrl,
-        state: interaction.providerState || interaction.provider_state || '[none]',
-        value: interaction
-    } as ParsedMockInteraction;
+const parseAsPactV4Body = (body: any) => {
+    if (!body) {
+        return undefined;
+    }
 
-    const getBodyPath = (bodyValue: any, bodyLocation: string, path: string) => {
-        let location = bodyLocation;
-        let value = bodyValue;
+    const { encoded, contents = '' } = body;
 
-        if (path) {
-            location += `${path}`;
-            value = _.get(value, path[0] === '.' ? path.substring(1) : path);
+    try {
+        if (!encoded) {
+            return contents;
         }
 
-        return {
-            location,
-            parentInteraction: parsedInteraction,
-            value
+        if ((encoded as string).toUpperCase() === 'JSON') {
+            return JSON.parse(contents); // throws if fails to parse
+        }
+
+        return Buffer.from(contents, encoded).toString(); // throws if unrecognised encoding
+    } catch {
+        return contents;
+    }
+};
+
+const passThrough = (x: any) => x;
+
+const parseInteractionFor = (mockPathOrUrl: string, version: number) => {
+    const parseBody = version >= 4 ? parseAsPactV4Body : passThrough;
+
+    return (interaction: PactInteraction, interactionIndex: number) => {
+        const parsedInteraction = {
+            description: interaction.description,
+            location: `[root].interactions[${interactionIndex}]`,
+            mockFile: mockPathOrUrl,
+            state: interaction.providerState || interaction.provider_state || '[none]',
+            value: interaction,
+        } as ParsedMockInteraction;
+
+        const getBodyPath = (bodyValue: any, bodyLocation: string, path: string) => {
+            let location = bodyLocation;
+            let value = bodyValue;
+
+            if (path) {
+                location += `${path}`;
+                value = _.get(value, path[0] === '.' ? path.substring(1) : path);
+            }
+
+            return {
+                location,
+                parentInteraction: parsedInteraction,
+                value,
+            };
         };
-    };
 
-    parsedInteraction.getRequestBodyPath = (path) =>
-        getBodyPath(interaction?.request?.body, `${parsedInteraction.location}.request.body`, path);
-    parsedInteraction.getResponseBodyPath = (path) =>
-        getBodyPath(interaction?.response?.body, `${parsedInteraction.location}.response.body`, path);
-    parsedInteraction.parentInteraction = parsedInteraction;
-    parsedInteraction.requestBody = {
-        location: `${parsedInteraction.location}.request.body`,
-        parentInteraction: parsedInteraction,
-        value: interaction.request.body
-    };
-    parsedInteraction.requestHeaders = parseHeaders(
-        interaction.request.headers, `${parsedInteraction.location}.request.headers`, parsedInteraction
-    );
-    parsedInteraction.requestMethod = {
-        location: `${parsedInteraction.location}.request.method`,
-        parentInteraction: parsedInteraction,
-        value: interaction.request.method.toLowerCase()
-    };
-    parsedInteraction.requestPath = {
-        location: `${parsedInteraction.location}.request.path`,
-        parentInteraction: parsedInteraction,
-        value: interaction.request.path
-    };
-    parsedInteraction.requestPathSegments = parseRequestPathSegments(interaction.request.path, parsedInteraction);
-    parsedInteraction.requestQuery = parseValues(
-        parseRequestQuery(interaction.request.query), `${parsedInteraction.location}.request.query`, parsedInteraction
-    );
-    parsedInteraction.responseBody = {
-        location: `${parsedInteraction.location}.response.body`,
-        parentInteraction: parsedInteraction,
-        value: interaction.response.body
-    };
-    parsedInteraction.responseHeaders = parseHeaders(
-        interaction.response.headers, `${parsedInteraction.location}.response.headers`, parsedInteraction
-    );
-    parsedInteraction.responseStatus = {
-        location: `${parsedInteraction.location}.response.status`,
-        parentInteraction: parsedInteraction,
-        value: interaction.response.status
-    };
+        parsedInteraction.getRequestBodyPath = (path) =>
+            getBodyPath(interaction?.request?.body, `${parsedInteraction.location}.request.body`, path);
 
-    return parsedInteraction;
+        parsedInteraction.getResponseBodyPath = (path) =>
+            getBodyPath(interaction?.response?.body, `${parsedInteraction.location}.response.body`, path);
+
+        parsedInteraction.parentInteraction = parsedInteraction;
+
+        parsedInteraction.requestBody = {
+            location: `${parsedInteraction.location}.request.body`,
+            parentInteraction: parsedInteraction,
+            value: parseBody(interaction.request.body),
+        };
+
+        parsedInteraction.requestHeaders = parseHeaders(
+            interaction.request.headers,
+            `${parsedInteraction.location}.request.headers`,
+            parsedInteraction
+        );
+
+        parsedInteraction.requestMethod = {
+            location: `${parsedInteraction.location}.request.method`,
+            parentInteraction: parsedInteraction,
+            value: interaction.request.method.toLowerCase(),
+        };
+
+        parsedInteraction.requestPath = {
+            location: `${parsedInteraction.location}.request.path`,
+            parentInteraction: parsedInteraction,
+            value: interaction.request.path,
+        };
+
+        parsedInteraction.requestPathSegments = parseRequestPathSegments(interaction.request.path, parsedInteraction);
+
+        parsedInteraction.requestQuery = parseValues(
+            parseRequestQuery(interaction.request.query),
+            `${parsedInteraction.location}.request.query`,
+            parsedInteraction
+        );
+
+        parsedInteraction.responseBody = {
+            location: `${parsedInteraction.location}.response.body`,
+            parentInteraction: parsedInteraction,
+            value: parseBody(interaction.response.body),
+        };
+
+        parsedInteraction.responseHeaders = parseHeaders(
+            interaction.response.headers,
+            `${parsedInteraction.location}.response.headers`,
+            parsedInteraction
+        );
+
+        parsedInteraction.responseStatus = {
+            location: `${parsedInteraction.location}.response.status`,
+            parentInteraction: parsedInteraction,
+            value: interaction.response.status,
+        };
+
+        return parsedInteraction;
+    };
 };
 
 const filterUnsupportedTypes = (interaction: PactInteraction) => {
     if (!interaction?.type || interaction.type === 'Synchronous/HTTP') {
-        return interaction
+        return interaction;
     }
-    return null
-}
+    return null;
+};
 
 export const pactParser = {
-    parse: (pactJson: Pact, mockPathOrUrl: string): ParsedMock => ({
-        consumer: pactJson.consumer.name,
-        interactions: pactJson.interactions.filter(interaction => filterUnsupportedTypes(interaction)).map((interaction: PactInteraction, interactionIndex: number) =>
-            parseInteraction(interaction, interactionIndex, mockPathOrUrl)
-        ),
-        pathOrUrl: mockPathOrUrl,
-        provider: pactJson.provider.name
-    })
+    parse: (pactJson: Pact, mockPathOrUrl: string): ParsedMock => {
+        const metadata = pactJson.metadata || pactJson.metaData;
+        const version = parseInt(
+            metadata?.pactSpecification?.version ||
+                metadata?.pactSpecificationVersion ||
+                metadata?.['pact-specification']?.version ||
+                '0'
+        );
+        const parseInteraction = parseInteractionFor(mockPathOrUrl, version);
+        return {
+            consumer: pactJson.consumer.name,
+            interactions: pactJson.interactions.filter(filterUnsupportedTypes).map(parseInteraction),
+            pathOrUrl: mockPathOrUrl,
+            provider: pactJson.provider.name,
+        };
+    },
 };

--- a/lib/swagger-mock-validator/mock-parser/pact/pact.d.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact.d.ts
@@ -1,7 +1,17 @@
+interface PactMetadata {
+    pactSpecification?: {
+        version?: string;
+    };
+    pactSpecificationVersion?: string;
+    'pact-specification'?: {
+        version?: string;
+    };
+}
 export interface Pact {
     consumer: { name: string };
     interactions: PactInteraction[];
-    metadata?: { pactSpecification?: {version?: string }};
+    metadata?: PactMetadata;
+    metaData?: PactMetadata;
     provider: { name: string };
 }
 
@@ -14,8 +24,8 @@ export interface PactInteraction {
     provider_state?: string;
 }
 
-export type PactV1RequestQuery = string
-export type PactV3RequestQuery = {[name: string]: string[]}
+export type PactV1RequestQuery = string;
+export type PactV3RequestQuery = { [name: string]: string[] };
 
 export interface PactInteractionRequest {
     headers?: PactInteractionHeaders;

--- a/test/unit/pact-parser.spec.ts
+++ b/test/unit/pact-parser.spec.ts
@@ -189,6 +189,36 @@ describe('pact-parser', () => {
                         status: 200,
                     },
                 },
+                {
+                    name: 'tolerates bad JSON',
+                    description: 'a request to update a product with existing id',
+                    request: {
+                        method: 'POST',
+                        path: '/products/27',
+                        body: {
+                            encoded: 'JSON',
+                            contents: '{ not: json }',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                    },
+                },
+                {
+                    name: 'tolerates bad encoding',
+                    description: 'a request to update a product with existing id',
+                    request: {
+                        method: 'POST',
+                        path: '/products/27',
+                        body: {
+                            encoded: 'foo',
+                            contents: 'abcdef',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                    },
+                },
             ],
             provider: {
                 name: 'ExampleProvider',
@@ -209,5 +239,8 @@ describe('pact-parser', () => {
         expect(pact.interactions[3].requestBody.value).toEqual({ hello: 'world' });
         expect(pact.interactions[4].requestBody.value).toEqual({ hello: 'world' });
         expect(pact.interactions[5].requestBody.value).toEqual('hello world');
+
+        expect(pact.interactions[6].requestBody.value).toEqual('{ not: json }');
+        expect(pact.interactions[7].requestBody.value).toEqual('abcdef');
     });
 });

--- a/test/unit/pact-parser.spec.ts
+++ b/test/unit/pact-parser.spec.ts
@@ -1,103 +1,213 @@
 import { pactParser } from '../../lib/swagger-mock-validator/mock-parser/pact/pact-parser';
-import { validateAndResolvePact } from '../../lib/swagger-mock-validator/validate-and-resolve-pact';
+import type { Pact } from '../../lib/swagger-mock-validator/mock-parser/pact/pact';
 
 describe('pact-parser', () => {
     it('should convert V3 formatted headers to v1 headers', () => {
-        const pactV3Json = {
-            'consumer': {
-                'name': 'ExampleConsumer'
+        const pactJson = {
+            consumer: {
+                name: 'ExampleConsumer',
             },
-            'interactions': [
+            interactions: [
                 {
-                    'name': 'sdfsdfsdf',
-                    'description': 'a request to retrieve a product with existing id',
-                    'request': {
-                        'headers': {
+                    name: 'sdfsdfsdf',
+                    description: 'a request to retrieve a product with existing id',
+                    request: {
+                        headers: {
                             'Content-Type': ['text/json'],
-                            'Accept': ['text/plain', 'application/json', 'text/json']
+                            Accept: ['text/plain', 'application/json', 'text/json'],
                         },
-                        'method': 'GET',
-                        'path': '/products/27'
+                        method: 'GET',
+                        path: '/products/27',
                     },
-                    'response': {
-                        'body': {
-                            'id': 27,
-                            'name': 'burger',
-                            'type': 'food'
+                    response: {
+                        body: {
+                            id: 27,
+                            name: 'burger',
+                            type: 'food',
                         },
-                        'headers': {
-                            'Content-Type': ['application/json']
+                        headers: {
+                            'Content-Type': ['application/json'],
                         },
-                        'status': 200
-                    }
-                }
+                        status: 200,
+                    },
+                },
             ],
-            'provider': {
-                'name': 'ExampleProvider'
-            }
-        }
+            provider: {
+                name: 'ExampleProvider',
+            },
+        };
 
-        const resolvedPact = validateAndResolvePact(pactV3Json, '../../pact_examples/pact.json');
-
-
-        const pact = pactParser.parse(resolvedPact, 'sdfsdf')
-        expect(pact.interactions[0].requestHeaders.Accept.value).toEqual('text/plain,application/json,text/json')
-        expect(pact.interactions[0].requestHeaders['Content-Type'].value).toEqual('text/json')
+        const pact = pactParser.parse(pactJson as unknown as Pact, 'sdfsdf');
+        expect(pact.interactions[0].requestHeaders.Accept.value).toEqual('text/plain,application/json,text/json');
+        expect(pact.interactions[0].requestHeaders['Content-Type'].value).toEqual('text/json');
     });
 
-    it('should filter out interactions that have a type defined other than \'Synchronous/HTTP\'', () => {
-
-        const pactV4Json = {
-            'consumer': {
-                'name': 'ExampleConsumer'
+    it("should filter out interactions that have a type defined other than 'Synchronous/HTTP'", () => {
+        const pactJson = {
+            consumer: {
+                name: 'ExampleConsumer',
             },
-            'interactions': [
+            interactions: [
                 {
-                    'name': 'no type defined pre pactv4 spec',
-                    'description': 'a request to retrieve a product with existing id',
-                    'request': {
-                        'method': 'GET',
-                        'path': '/products/27'
+                    name: 'no type defined pre pactv4 spec',
+                    description: 'a request to retrieve a product with existing id',
+                    request: {
+                        method: 'GET',
+                        path: '/products/27',
                     },
-                    'response': {
-                        'status': 200
-                    }
+                    response: {
+                        status: 200,
+                    },
                 },
                 {
-                    'name': 'Synchronous/HTTP defined',
-                    'type': 'Synchronous/HTTP',
-                    'description': 'a request to retrieve a product with existing id',
-                    'request': {
-                        'method': 'GET',
-                        'path': '/products/27'
+                    name: 'Synchronous/HTTP defined',
+                    type: 'Synchronous/HTTP',
+                    description: 'a request to retrieve a product with existing id',
+                    request: {
+                        method: 'GET',
+                        path: '/products/27',
                     },
-                    'response': {
-                        'status': 200
-                    }
+                    response: {
+                        status: 200,
+                    },
                 },
                 {
-                    'name': 'different type defined',
-                    'type': 'Asynchronous/Messages',
-                    'description': 'a request to retrieve a product with existing id',
-                    'request': {
-                        'method': 'GET',
-                        'path': '/products/27'
+                    name: 'different type defined',
+                    type: 'Asynchronous/Messages',
+                    description: 'a request to retrieve a product with existing id',
+                    request: {
+                        method: 'GET',
+                        path: '/products/27',
                     },
-                    'response': {
-                        'status': 200
-                    }
-                }
+                    response: {
+                        status: 200,
+                    },
+                },
             ],
-            'provider': {
-                'name': 'ExampleProvider'
-            }
-        }
+            provider: {
+                name: 'ExampleProvider',
+            },
+        };
 
+        const pact = pactParser.parse(pactJson as unknown as Pact, 'sdfsdf');
+        expect(pact.interactions.length).toEqual(2);
+    });
 
-        const resolvedPact = validateAndResolvePact(pactV4Json, '../../pact_examples/pact.json');
+    it('should parse V4 body types', () => {
+        const pactJson = {
+            consumer: {
+                name: 'ExampleConsumer',
+            },
+            interactions: [
+                {
+                    name: 'JSON response',
+                    description: 'a request to retrieve a product with existing id',
+                    request: {
+                        method: 'GET',
+                        path: '/products/27',
+                    },
+                    response: {
+                        status: 200,
+                        body: {
+                            encoded: false,
+                            contents: { hello: 'world' },
+                        },
+                    },
+                },
+                {
+                    name: 'encoded JSON response',
+                    description: 'a request to retrieve a product with existing id',
+                    request: {
+                        method: 'GET',
+                        path: '/products/27',
+                    },
+                    response: {
+                        status: 200,
+                        body: {
+                            encoded: 'JSON',
+                            contents: '{ "hello": "world" }',
+                        },
+                    },
+                },
+                {
+                    name: 'encoded string response',
+                    description: 'a request to retrieve a product with existing id',
+                    request: {
+                        method: 'GET',
+                        path: '/products/27',
+                    },
+                    response: {
+                        status: 200,
+                        body: {
+                            encoded: 'base64',
+                            contents: 'aGVsbG8gd29ybGQ=',
+                        },
+                    },
+                },
+                {
+                    name: 'JSON response',
+                    description: 'a request to update a product with existing id',
+                    request: {
+                        method: 'POST',
+                        path: '/products/27',
+                        body: {
+                            encoded: false,
+                            contents: { hello: 'world' },
+                        },
+                    },
+                    response: {
+                        status: 200,
+                    },
+                },
+                {
+                    name: 'encoded JSON response',
+                    description: 'a request to update a product with existing id',
+                    request: {
+                        method: 'POST',
+                        path: '/products/27',
+                        body: {
+                            encoded: 'JSON',
+                            contents: '{ "hello": "world" }',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                    },
+                },
+                {
+                    name: 'encoded string response',
+                    description: 'a request to update a product with existing id',
+                    request: {
+                        method: 'POST',
+                        path: '/products/27',
+                        body: {
+                            encoded: 'base64',
+                            contents: 'aGVsbG8gd29ybGQ=',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                    },
+                },
+            ],
+            provider: {
+                name: 'ExampleProvider',
+            },
+            metadata: {
+                pactSpecification: {
+                    version: '4.0.0',
+                },
+            },
+        };
 
+        const pact = pactParser.parse(pactJson as unknown as Pact, 'sdfsdf');
 
-        const pact = pactParser.parse(resolvedPact, 'sdfsdf')
-        expect(pact.interactions.length).toEqual(2)
+        expect(pact.interactions[0].responseBody.value).toEqual({ hello: 'world' });
+        expect(pact.interactions[1].responseBody.value).toEqual({ hello: 'world' });
+        expect(pact.interactions[2].responseBody.value).toEqual('hello world');
+
+        expect(pact.interactions[3].requestBody.value).toEqual({ hello: 'world' });
+        expect(pact.interactions[4].requestBody.value).toEqual({ hello: 'world' });
+        expect(pact.interactions[5].requestBody.value).toEqual('hello world');
     });
 });


### PR DESCRIPTION
This PR treats the first 2 of the following bodies as the same:
```
{
  "contents": { "a": 1 },
  "encoded": false,
  "contentType": "application/json"
}
{
  "contents": "{\"a\":1}",
  "encoded": "JSON",
  "contentType": "application/json"
}
{
  "contents": "eyJhIjoxfQ==",
  "encoded": "base64",
  "contentType": "application/json"
}
```

I decided that even though, I could've base64 decoded the contents of the 3rd body to arrive at `{"a":1}`, and subsequently parsing it as `application/json`, that is too far a stretch to be realistic. In this case, we simply return the contents as `{"a":1}` (the string)
