### PR TITLE
fix: handle exclusiveMinimum/exclusiveMaximum in bodies

### DIFF
--- a/lib/swagger-mock-validator/spec-parser/openapi3/openapi3-parser/to-parsed-spec-parameter.ts
+++ b/lib/swagger-mock-validator/spec-parser/openapi3/openapi3-parser/to-parsed-spec-parameter.ts
@@ -15,12 +15,8 @@ const isParameterSchemaUnsupported = (schema: ParsedSpecJsonSchemaCore): boolean
 
 // draft-06 onwards converts exclusiveMinimum and exclusiveMaximum to numbers
 const upgradeSchema = (schema: ParsedSpecJsonSchemaCore): ParsedSpecJsonSchemaCore => {
-    if (schema.exclusiveMaximum) {
-        schema.exclusiveMaximum = schema.maximum;
-    }
-    if (schema.exclusiveMinimum) {
-        schema.exclusiveMinimum = schema.minimum;
-    }
+    schema.exclusiveMaximum = schema.exclusiveMaximum ? schema.maximum : undefined;
+    schema.exclusiveMinimum = schema.exclusiveMinimum ? schema.minimum : undefined;
     return schema;
 };
 

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-request-body.ts
@@ -23,6 +23,12 @@ const transformSchema = (
         }
     });
 
+    // draft-06 onwards converts exclusiveMinimum and exclusiveMaximum to numbers
+    traverseJsonSchema(modifiedSchema, (mutableSchema) => {
+        mutableSchema.exclusiveMaximum = mutableSchema.exclusiveMaximum ? mutableSchema.maximum : undefined;
+        mutableSchema.exclusiveMinimum = mutableSchema.exclusiveMinimum ? mutableSchema.minimum : undefined;
+    });
+
     return modifiedSchema;
 };
 

--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
@@ -50,6 +50,12 @@ const transformSchema = (
         }
     });
 
+    // draft-06 onwards converts exclusiveMinimum and exclusiveMaximum to numbers
+    traverseJsonSchema(modifiedSchema, (mutableSchema) => {
+        mutableSchema.exclusiveMaximum = mutableSchema.exclusiveMaximum ? mutableSchema.maximum : undefined;
+        mutableSchema.exclusiveMinimum = mutableSchema.exclusiveMinimum ? mutableSchema.minimum : undefined;
+    });
+
     return modifiedSchema;
 };
 

--- a/test/e2e/fixtures/openapi3-provider.yaml
+++ b/test/e2e/fixtures/openapi3-provider.yaml
@@ -41,6 +41,12 @@ components:
           type: string
         email:
           type: string
+        age:
+          type: integer
+          minimum: 19
+          exclusiveMinimum: true
+          maximum: 100
+          exclusiveMaximum: false
       required:
       - userId
       - firstName


### PR DESCRIPTION
We previously converted exclusiveMin/Max in parameters, but not in bodies. We should do it there as well.

While we're at it, we should properly handle when the value is `false`.