### PR TITLE
Feat: Bearer token based auth for Pact Brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,22 @@ pacts from the broker by Pact Broker version tags.
 If the pact broker has basic auth enabled, pass a --user option with username and password joined by a colon
 (i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.
 
+If the pact broker has bearer token auth enabled, pass a --token option along with the token to access the pact broker resources.
+
+You can also set the following environment variables
+
+- Basic Auth
+  - `PACT_BROKER_USERNAME`
+  - `PACT_BROKER_PASSWORD`
+- Bearer Auth
+  - `PACT_BROKER_TOKEN`
+
 Options:
   -V, --version                                   output the version number
   -p, --provider [string]                         The name of the provider in the pact broker
   -t, --tag [string]                              The tag to filter pacts retrieved from the pact broker
   -u, --user [USERNAME:PASSWORD]                  The basic auth username and password to access the pact broker
+  -u, --token [string]                            The bearer token to access the pact broker
   -a, --analyticsUrl [string]                     The url to send analytics events to as a http post
   -o, --outputDepth [integer]                     Specifies the number of times to recurse while formatting the output objects. This is useful in case of large complicated objects or schemas. (default: 4)
   -A, --additionalPropertiesInResponse [boolean]  allow additional properties in response bodies, default false
@@ -354,6 +365,22 @@ swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider 
 If the Pact Broker is behind basic auth, you can pass credentials with the `--user` option while invoking the tool.
 ```
 swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider my-provider-name --user BASIC_AUTH_USER:BASIC_AUTH_PASSWORD
+```
+
+You can also use environment variables
+```
+PACT_BROKER_USERNAME=BASIC_AUTH_USER PACT_BROKER_PASSWORD=BASIC_AUTH_PASSWORD swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider my-provider-name
+```
+
+If the Pact Broker is behind bearer auth, you can pass credentials with the `--token` option while invoking the tool.
+
+```
+swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider my-provider-name --token bar
+```
+
+You can also use environment variables
+```
+PACT_BROKER_TOKEN=bar swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider my-provider-name
 ```
 
 ### Analytics (Opt-In)

--- a/README.md
+++ b/README.md
@@ -89,12 +89,14 @@ You can also set the following environment variables
 - Bearer Auth
   - `PACT_BROKER_TOKEN`
 
+Note: command line options will take precedence over environment variables.
+
 Options:
   -V, --version                                   output the version number
   -p, --provider [string]                         The name of the provider in the pact broker
   -t, --tag [string]                              The tag to filter pacts retrieved from the pact broker
-  -u, --user [USERNAME:PASSWORD]                  The basic auth username and password to access the pact broker
-  -u, --token [string]                            The bearer token to access the pact broker
+  -u, --user [USERNAME:PASSWORD]                  The basic auth username and password to access the pact broker (env - PACT_BROKER_USERNAME:PACT_BROKER_PASSWORD)
+  -u, --token [string]                            The bearer token to access the pact broker (env - PACT_BROKER_TOKEN)
   -a, --analyticsUrl [string]                     The url to send analytics events to as a http post
   -o, --outputDepth [integer]                     Specifies the number of times to recurse while formatting the output objects. This is useful in case of large complicated objects or schemas. (default: 4)
   -A, --additionalPropertiesInResponse [boolean]  allow additional properties in response bodies, default false

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -48,6 +48,7 @@ program
     .option('-p, --provider [string]', 'The name of the provider in the pact broker')
     .option('-t, --tag [string]', 'The tag to filter pacts retrieved from the pact broker')
     .option('-u, --user [USERNAME:PASSWORD]', 'The basic auth username and password to access the pact broker')
+    .option('-b, --token [string]', 'The bearer token to access the pact broker')
     .option('-a, --analyticsUrl [string]', 'The url to send analytics events to as a http post')
     .option('-o, --outputDepth [integer]', 'Specifies the number of times to recurse ' +
     'while formatting the output objects. ' +
@@ -76,7 +77,12 @@ If the pact broker has basic auth enabled, pass a --user option with username an
     )
     .action(async (swagger, mock, options) => {
         try {
-            const swaggerMockValidator = SwaggerMockValidatorFactory.create(options.user);
+            if (!options.user && process.env.PACT_BROKER_USERNAME != '' && process.env.PACT_BROKER_PASSWORD != '') {
+                options.user = process.env.PACT_BROKER_USERNAME + ':' + process.env.PACT_BROKER_PASSWORD;
+            } else if (!options.token && process.env.PACT_BROKER_TOKEN != '') {
+                options.token = process.env.PACT_BROKER_TOKEN;
+            }
+            const swaggerMockValidator = SwaggerMockValidatorFactory.create(options.user ?? options.token);
 
             const result = await swaggerMockValidator.validate({
                 analyticsUrl: options.analyticsUrl,

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -47,8 +47,8 @@ program
     .arguments('<swagger> <mock>')
     .option('-p, --provider [string]', 'The name of the provider in the pact broker')
     .option('-t, --tag [string]', 'The tag to filter pacts retrieved from the pact broker')
-    .option('-u, --user [USERNAME:PASSWORD]', 'The basic auth username and password to access the pact broker')
-    .option('-b, --token [string]', 'The bearer token to access the pact broker')
+    .option('-u, --user [USERNAME:PASSWORD]', 'The basic auth username and password to access the pact broker (env - PACT_BROKER_USERNAME:PACT_BROKER_PASSWORD)')
+    .option('-b, --token [string]', 'The bearer token to access the pact broker (env - PACT_BROKER_TOKEN)')
     .option('-a, --analyticsUrl [string]', 'The url to send analytics events to as a http post')
     .option('-o, --outputDepth [integer]', 'Specifies the number of times to recurse ' +
     'while formatting the output objects. ' +
@@ -73,7 +73,20 @@ json file. Optionally, pass a --tag option alongside a --provider option to filt
 pacts from the broker by Pact Broker version tags.
 
 If the pact broker has basic auth enabled, pass a --user option with username and password joined by a colon
-(i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.`
+(i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.
+
+If the pact broker has bearer token auth enabled, pass a --token option along with the token to access the pact broker resources.
+
+You can also set the following environment variables
+
+- Basic Auth
+  - PACT_BROKER_USERNAME
+  - PACT_BROKER_PASSWORD
+- Bearer Auth
+  - PACT_BROKER_TOKEN
+
+Note: command line options will take precedence over environment variables.
+`
     )
     .action(async (swagger, mock, options) => {
         try {

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -77,9 +77,13 @@ If the pact broker has basic auth enabled, pass a --user option with username an
     )
     .action(async (swagger, mock, options) => {
         try {
-            if (!options.user && process.env.PACT_BROKER_USERNAME != '' && process.env.PACT_BROKER_PASSWORD != '') {
+            if (
+                options.user == undefined &&
+                process.env.PACT_BROKER_USERNAME != undefined &&
+                process.env.PACT_BROKER_PASSWORD != undefined
+            ) {
                 options.user = process.env.PACT_BROKER_USERNAME + ':' + process.env.PACT_BROKER_PASSWORD;
-            } else if (!options.token && process.env.PACT_BROKER_TOKEN != '') {
+            } else if (options.token == undefined && process.env.PACT_BROKER_TOKEN != undefined) {
                 options.token = process.env.PACT_BROKER_TOKEN;
             }
             const swaggerMockValidator = SwaggerMockValidatorFactory.create(options.user ?? options.token);

--- a/lib/swagger-mock-validator/clients/http-client.ts
+++ b/lib/swagger-mock-validator/clients/http-client.ts
@@ -2,9 +2,19 @@ import axios from 'axios';
 
 export class HttpClient {
     public async get(url: string, auth?: string): Promise<string> {
+        let authHeader: string | undefined;
+
+        if (auth) {
+            if (auth.includes(':')) {
+                authHeader = 'Basic ' + Buffer.from(auth).toString('base64');
+            } else {
+                authHeader = 'Bearer ' + auth;
+            }
+        }
+
         const response = await axios.get(url, {
             headers: {
-              ...(auth ? {authorization: 'Basic ' + Buffer.from(auth).toString('base64')} : {})
+                ...(authHeader ? { Authorization: authHeader } : {})
             },
             timeout: 30000,
             transformResponse: (data) => data,

--- a/test/e2e/cli.spec.ts
+++ b/test/e2e/cli.spec.ts
@@ -387,6 +387,21 @@ describe('swagger-mock-validator/cli', () => {
             jasmine.stringMatching('test/e2e/fixtures/pact-broker.json')
         );
     }, 30000);
+    it('should make an bearer token authenticated request to the provided pact broker url when asked to do so', async () => {
+        const auth = 'token';
+
+        await invokeCommand({
+            auth,
+            mock: urlTo('test/e2e/fixtures/pact-broker.json'),
+            providerName: 'provider-1',
+            swagger: urlTo('test/e2e/fixtures/swagger-provider.json')
+        });
+
+        expect(mockPactBroker.get).toHaveBeenCalledWith(
+            jasmine.objectContaining({authorization: 'Bearer token'}),
+            jasmine.stringMatching('test/e2e/fixtures/pact-broker.json')
+        );
+    }, 30000);
 
     it('should format output objects to depth 0', async () => {
         const result = await invokeCommand({

--- a/test/e2e/cli.spec.ts
+++ b/test/e2e/cli.spec.ts
@@ -8,11 +8,13 @@ import {expectToFail} from '../helpers/expect-to-fail';
 interface InvokeCommandOptions {
     analyticsUrl?: string;
     auth?: string;
+    token?: string;
     mock: string;
     providerName?: string;
     swagger: string;
     tag?: string;
     outputDepth?: string;
+    envVars?: string;
 }
 
 const execute = (command: string): Promise<string> => {
@@ -28,7 +30,9 @@ const execute = (command: string): Promise<string> => {
 };
 
 const invokeCommand = (options: InvokeCommandOptions): Promise<string> => {
-    let command = `./bin/swagger-mock-validator.mjs ${options.swagger} ${options.mock}`;
+    let command = `${options.envVars ? `${options.envVars} ` : ''}./bin/swagger-mock-validator.mjs ${options.swagger} ${
+        options.mock
+    }`;
 
     if (options.providerName) {
         command += ` --provider ${options.providerName}`;
@@ -44,6 +48,10 @@ const invokeCommand = (options: InvokeCommandOptions): Promise<string> => {
 
     if (options.auth) {
         command += ` --user ${options.auth}`;
+    }
+
+    if (options.token) {
+        command += ` --token ${options.token}`;
     }
 
     if (options.outputDepth) {
@@ -388,10 +396,10 @@ describe('swagger-mock-validator/cli', () => {
         );
     }, 30000);
     it('should make an bearer token authenticated request to the provided pact broker url when asked to do so', async () => {
-        const auth = 'token';
+        const token = 'token';
 
         await invokeCommand({
-            auth,
+            token,
             mock: urlTo('test/e2e/fixtures/pact-broker.json'),
             providerName: 'provider-1',
             swagger: urlTo('test/e2e/fixtures/swagger-provider.json')
@@ -402,7 +410,70 @@ describe('swagger-mock-validator/cli', () => {
             jasmine.stringMatching('test/e2e/fixtures/pact-broker.json')
         );
     }, 30000);
+    it('should make an authenticated request with a user/pass combo read from PACT_BROKER_USERNAME/PACT_BROKER_PASSWORD variable', async () => {
+        const user = 'user';
+        const pass = 'pass';
 
+        await invokeCommand({
+            envVars: `PACT_BROKER_USERNAME=${user} PACT_BROKER_PASSWORD=${pass}`,
+            mock: urlTo('test/e2e/fixtures/pact-broker.json'),
+            providerName: 'provider-1',
+            swagger: urlTo('test/e2e/fixtures/swagger-provider.json')
+        });
+
+        expect(mockPactBroker.get).toHaveBeenCalledWith(
+            jasmine.objectContaining({authorization: 'Basic dXNlcjpwYXNz'}),
+            jasmine.stringMatching('test/e2e/fixtures/pact-broker.json')
+        );
+    }, 30000);
+    it('should make an authenticated request with a bearer token read from PACT_BROKER_TOKEN variable', async () => {
+        const token = 'token';
+
+        await invokeCommand({
+            envVars: `PACT_BROKER_TOKEN=${token}`,
+            mock: urlTo('test/e2e/fixtures/pact-broker.json'),
+            providerName: 'provider-1',
+            swagger: urlTo('test/e2e/fixtures/swagger-provider.json')
+        });
+
+        expect(mockPactBroker.get).toHaveBeenCalledWith(
+            jasmine.objectContaining({authorization: 'Bearer token'}),
+            jasmine.stringMatching('test/e2e/fixtures/pact-broker.json')
+        );
+    }, 30000);
+    it('should prefer user variable, even if PACT_BROKER_USERNAME/PACT_BROKER_PASSWORD variable are set', async () => {
+        const user = 'user';
+        const pass = 'pass';
+
+        await invokeCommand({
+            auth: `${user}:${pass}`,
+            envVars: `PACT_BROKER_USERNAME=${user}_env PACT_BROKER_PASSWORD=${pass}_env`,
+            mock: urlTo('test/e2e/fixtures/pact-broker.json'),
+            providerName: 'provider-1',
+            swagger: urlTo('test/e2e/fixtures/swagger-provider.json')
+        });
+
+        expect(mockPactBroker.get).toHaveBeenCalledWith(
+            jasmine.objectContaining({authorization: 'Basic dXNlcjpwYXNz'}),
+            jasmine.stringMatching('test/e2e/fixtures/pact-broker.json')
+        );
+    }, 30000);
+    it('should prefer user variable, even if PACT_BROKER_TOKEN variable are set', async () => {
+        const token = 'token';
+
+        await invokeCommand({
+            token,
+            envVars: `PACT_BROKER_TOKEN=${token}_env`,
+            mock: urlTo('test/e2e/fixtures/pact-broker.json'),
+            providerName: 'provider-1',
+            swagger: urlTo('test/e2e/fixtures/swagger-provider.json')
+        });
+
+        expect(mockPactBroker.get).toHaveBeenCalledWith(
+            jasmine.objectContaining({authorization: 'Bearer token'}),
+            jasmine.stringMatching('test/e2e/fixtures/pact-broker.json')
+        );
+    }, 30000);
     it('should format output objects to depth 0', async () => {
         const result = await invokeCommand({
             mock: 'test/e2e/fixtures/pact-working-consumer.json',


### PR DESCRIPTION
It would be nice to also be able to support Bearer based tokens, for Bearer protected Brokers.

The Open source Pact Broker does not provide this out of the box, however PactFlow does, and users of the open source broker, may roll their own auth mechanisms to support a bearer token.

The following curl request will retrieve a pact from a bearer protected Broker (example PactFlow)

```console
curl -H "Authorization: Bearer $PACT_BROKER_TOKEN" https://testdemo.pactflow.io/pacts/provider/pact-provider-poc/consumer/pact-consumer-poc/version/9191e17 | jq .
```

Most users will have the following combos of env vars, depending on their setup

`PACT_BROKER_BASE_URL`

Basic Auth

`PACT_BROKER_USERNAME`
`PACT_BROKER_PASSWORD`

Bearer Auth

`PACT_BROKER_TOKEN`

There it would be reasonable to assume, that these are set or are easily set in a users local, or ci environment.

Only read-only tokens are required, as no write actions are performed on a broker