### PR TITLE
Feat: Support retrieving OAS provider contracts from PactFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,16 @@ the specified provider name. The <swagger> argument should be the path or url to
 json file. Optionally, pass a --tag option alongside a --provider option to filter the retrieved
 pacts from the broker by Pact Broker version tags.
 
-If the pact broker has basic auth enabled, pass a --user option with username and password joined by a colon
-(i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.
+If the pact broker has auth enabled, set the necessary env vars to access the pact broker resources.
+
+PACT_BROKER_USERNAME
+PACT_BROKER_PASSWORD
+PACT_BROKER_TOKEN
 
 Options:
   -V, --version                                   output the version number
   -p, --provider [string]                         The name of the provider in the pact broker
   -t, --tag [string]                              The tag to filter pacts retrieved from the pact broker
-  -u, --user [USERNAME:PASSWORD]                  The basic auth username and password to access the pact broker
   -a, --analyticsUrl [string]                     The url to send analytics events to as a http post
   -o, --outputDepth [integer]                     Specifies the number of times to recurse while formatting the output objects. This is useful in case of large complicated objects or schemas. (default: 4)
   -A, --additionalPropertiesInResponse [boolean]  allow additional properties in response bodies, default false
@@ -351,9 +353,15 @@ Additionally, provide a Pact Broker version tag alongside the name of the provid
 swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider my-provider-name --tag production
 ```
 
-If the Pact Broker is behind basic auth, you can pass credentials with the `--user` option while invoking the tool.
+If the Pact Broker is behind basic auth, you can pass credentials with env vars while invoking the tool.
+
 ```
-swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider my-provider-name --user BASIC_AUTH_USER:BASIC_AUTH_PASSWORD
+PACT_BROKER_USERNAME=foo PACT_BROKER_PASSWORD=bar swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider my-provider-name
+```
+
+If the Pact Broker is behind bearer auth, you can pass credentials with env vars while invoking the tool.
+```
+PACT_BROKER_TOKEN=bar swagger-mock-validator /path/to/swagger.json https://pact-broker.com --provider my-provider-name
 ```
 
 ### Analytics (Opt-In)

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -72,7 +72,18 @@ json file. Optionally, pass a --tag option alongside a --provider option to filt
 pacts from the broker by Pact Broker version tags.
 
 If the pact broker has basic auth enabled, pass a --user option with username and password joined by a colon
-(i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.`
+(i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.
+
+Alternatively you can set access pact broker resources, by setting the following env vars
+
+Basic Auth
+
+PACT_BROKER_USERNAME
+PACT_BROKER_PASSWORD
+
+Bearer Token Auth
+
+PACT_BROKER_TOKEN`
     )
     .action(async (swagger, mock, options) => {
         try {

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -47,7 +47,6 @@ program
     .arguments('<swagger> <mock>')
     .option('-p, --provider [string]', 'The name of the provider in the pact broker')
     .option('-t, --tag [string]', 'The tag to filter pacts retrieved from the pact broker')
-    .option('-u, --user [USERNAME:PASSWORD]', 'The basic auth username and password to access the pact broker')
     .option('-a, --analyticsUrl [string]', 'The url to send analytics events to as a http post')
     .option('-o, --outputDepth [integer]', 'Specifies the number of times to recurse ' +
     'while formatting the output objects. ' +
@@ -71,10 +70,7 @@ the specified provider name. The <swagger> argument should be the path or url to
 json file. Optionally, pass a --tag option alongside a --provider option to filter the retrieved
 pacts from the broker by Pact Broker version tags.
 
-If the pact broker has basic auth enabled, pass a --user option with username and password joined by a colon
-(i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.
-
-Alternatively you can set access pact broker resources, by setting the following env vars
+If the pact broker has auth enabled, you can access pact broker resources, by setting the following env vars
 
 Basic Auth
 
@@ -87,7 +83,7 @@ PACT_BROKER_TOKEN`
     )
     .action(async (swagger, mock, options) => {
         try {
-            const swaggerMockValidator = SwaggerMockValidatorFactory.create(options.user);
+            const swaggerMockValidator = SwaggerMockValidatorFactory.create();
 
             const result = await swaggerMockValidator.validate({
                 analyticsUrl: options.analyticsUrl,

--- a/lib/swagger-mock-validator-factory.ts
+++ b/lib/swagger-mock-validator-factory.ts
@@ -9,13 +9,13 @@ import {PactBroker} from './swagger-mock-validator/pact-broker';
 import {UuidGenerator} from './swagger-mock-validator/uuid-generator';
 
 export class SwaggerMockValidatorFactory {
-    public static create(auth?: string): SwaggerMockValidator {
+    public static create(): SwaggerMockValidator {
         const fileSystem = new FileSystem();
         const httpClient = new HttpClient();
         const uuidGenerator = new UuidGenerator();
         const metadata = new Metadata();
         const fileStore = new FileStore(fileSystem, httpClient);
-        const pactBrokerClient = new PactBrokerClient(httpClient, auth);
+        const pactBrokerClient = new PactBrokerClient(httpClient);
         const pactBroker = new PactBroker(pactBrokerClient);
         const analytics = new Analytics(httpClient, uuidGenerator, metadata);
         return new SwaggerMockValidator(fileStore, pactBroker, analytics);

--- a/lib/swagger-mock-validator/clients/http-client.ts
+++ b/lib/swagger-mock-validator/clients/http-client.ts
@@ -1,8 +1,7 @@
 import axios from 'axios';
 
 export class HttpClient {
-    public async get(url: string, auth?: string): Promise<string> {
-        console.log(auth);
+    public async get(url: string): Promise<string> {
         let authHeader: string | undefined;
         if (process.env.PACT_BROKER_TOKEN != '') {
             authHeader = 'Bearer ' + process.env.PACT_BROKER_TOKEN;
@@ -12,8 +11,6 @@ export class HttpClient {
                 Buffer.from(`${process.env.PACT_BROKER_USERNAME}:${process.env.PACT_BROKER_PASSWORD}`).toString(
                     'base64'
                 );
-        } else if (auth) {
-            authHeader = auth.includes(':') ? 'Bearer ' + auth : 'Basic ' + Buffer.from(auth).toString('base64');
         }
 
         const response = await axios.get(url, {

--- a/lib/swagger-mock-validator/clients/pact-broker-client.ts
+++ b/lib/swagger-mock-validator/clients/pact-broker-client.ts
@@ -3,12 +3,12 @@ import {transformStringToObject} from '../transform-string-to-object';
 import {HttpClient} from './http-client';
 
 export class PactBrokerClient {
-    public constructor(private readonly httpClient: HttpClient, private readonly auth?: string) {
+    public constructor(private readonly httpClient: HttpClient) {
     }
 
     public async loadAsObject<T>(url: string): Promise<T> {
         try {
-            const content = await this.httpClient.get(url, this.auth);
+            const content = await this.httpClient.get(url);
 
             return transformStringToObject<T>(content, url);
         } catch (error) {
@@ -20,7 +20,7 @@ export class PactBrokerClient {
 
     public async loadAsString(url: string): Promise<string> {
         try {
-            return await this.httpClient.get(url, this.auth);
+            return await this.httpClient.get(url);
         } catch (error) {
             throw new SwaggerMockValidatorErrorImpl(
                 'SWAGGER_MOCK_VALIDATOR_READ_ERROR', `Unable to read "${url}"`, error

--- a/lib/swagger-mock-validator/file-store.ts
+++ b/lib/swagger-mock-validator/file-store.ts
@@ -1,6 +1,6 @@
-import {FileSystem} from './clients/file-system';
-import {HttpClient} from './clients/http-client';
-import {SwaggerMockValidatorErrorImpl} from './swagger-mock-validator-error-impl';
+import { FileSystem } from './clients/file-system';
+import { HttpClient } from './clients/http-client';
+import { SwaggerMockValidatorErrorImpl } from './swagger-mock-validator-error-impl';
 
 export class FileStore {
     public static isUrl(pathOrUrl: string): boolean {
@@ -11,10 +11,18 @@ export class FileStore {
 
     public async loadFile(pathOrUrl: string): Promise<string> {
         try {
-            return await this.loadPathOrUrl(pathOrUrl);
+            if (process.env.PACT_BROKER_TOKEN != '' && pathOrUrl.includes('internal/contracts/bi-directional')) {
+                const result = await this.loadPathOrUrl(pathOrUrl);
+                const providerContractContent = JSON.parse(result)._embedded['providerContract']['content'];
+                return Promise.resolve(providerContractContent);
+            } else {
+                return await this.loadPathOrUrl(pathOrUrl);
+            }
         } catch (error) {
             throw new SwaggerMockValidatorErrorImpl(
-                'SWAGGER_MOCK_VALIDATOR_READ_ERROR', `Unable to read "${pathOrUrl}"`, error
+                'SWAGGER_MOCK_VALIDATOR_READ_ERROR',
+                `Unable to read "${pathOrUrl}"`,
+                error
             );
         }
     }

--- a/test/e2e/cli.spec.ts
+++ b/test/e2e/cli.spec.ts
@@ -7,7 +7,6 @@ import {expectToFail} from '../helpers/expect-to-fail';
 
 interface InvokeCommandOptions {
     analyticsUrl?: string;
-    auth?: string;
     mock: string;
     providerName?: string;
     swagger: string;
@@ -40,10 +39,6 @@ const invokeCommand = (options: InvokeCommandOptions): Promise<string> => {
 
     if (options.analyticsUrl) {
         command += ` --analyticsUrl ${options.analyticsUrl}`;
-    }
-
-    if (options.auth) {
-        command += ` --user ${options.auth}`;
     }
 
     if (options.outputDepth) {
@@ -369,22 +364,6 @@ describe('swagger-mock-validator/cli', () => {
         expect(result).toEqual(jasmine.stringMatching('2 warning'));
         expect(result).toEqual(
             jasmine.stringMatching('Request header is not defined in the spec file: x-unknown-header')
-        );
-    }, 30000);
-
-    it('should make an authenticated request to the provided pact broker url when asked to do so', async () => {
-        const auth = 'user:pass';
-
-        await invokeCommand({
-            auth,
-            mock: urlTo('test/e2e/fixtures/pact-broker.json'),
-            providerName: 'provider-1',
-            swagger: urlTo('test/e2e/fixtures/swagger-provider.json')
-        });
-
-        expect(mockPactBroker.get).toHaveBeenCalledWith(
-            jasmine.objectContaining({authorization: 'Basic dXNlcjpwYXNz'}),
-            jasmine.stringMatching('test/e2e/fixtures/pact-broker.json')
         );
     }, 30000);
 

--- a/test/unit/reading-urls.spec.ts
+++ b/test/unit/reading-urls.spec.ts
@@ -154,7 +154,7 @@ describe('reading urls', () => {
         it('should make a request to the root of the pact broker', async () => {
             await invokeValidateWithPactBroker('http://pact-broker.com', 'provider-name');
 
-            expect(mockHttpClient.get).toHaveBeenCalledWith('http://pact-broker.com', undefined);
+            expect(mockHttpClient.get).toHaveBeenCalledWith('http://pact-broker.com');
         });
 
         it('should fail when the request to the root of the pact broker fails', async () => {
@@ -192,7 +192,7 @@ describe('reading urls', () => {
 
             await invokeValidateWithPactBroker('http://pact-broker.com', 'provider-name');
 
-            expect(mockHttpClient.get).toHaveBeenCalledWith('http://pact-broker.com/provider-name/pacts', undefined);
+            expect(mockHttpClient.get).toHaveBeenCalledWith('http://pact-broker.com/provider-name/pacts');
         });
 
         it('should fail when the request for the latest pact files fails', async () => {
@@ -247,9 +247,9 @@ describe('reading urls', () => {
             await invokeValidateWithPactBroker('http://pact-broker.com', 'provider-name');
 
             expect(mockHttpClient.get)
-                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/consumer-1/pact', undefined);
+                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/consumer-1/pact');
             expect(mockHttpClient.get)
-                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/consumer-2/pact', undefined);
+                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/consumer-2/pact');
         });
 
         it('should fail when the request for one of the provider pact files fails', async () => {
@@ -398,7 +398,7 @@ describe('reading urls', () => {
 
             await invokeValidateWithPactBroker('http://pact-broker.com', 'provider/name');
 
-            expect(mockHttpClient.get).toHaveBeenCalledWith('http://pact-broker.com/provider%2Fname/pacts', undefined);
+            expect(mockHttpClient.get).toHaveBeenCalledWith('http://pact-broker.com/provider%2Fname/pacts');
         });
     });
 
@@ -415,19 +415,17 @@ describe('reading urls', () => {
                 Promise.resolve(JSON.stringify(pactBuilder.build()));
         });
 
-        const invokeValidateWithPactBrokerAndAuth = (pactBrokerUrl: string, providerName: string, auth: string) => {
-            return invokeValidate({
-                auth,
-                mockPathOrUrl: pactBrokerUrl,
+        const invokeValidateWithPactBrokerAndAuth = (pactBrokerUrl: string, providerName: string) => {
+            return invokeValidate({mockPathOrUrl: pactBrokerUrl,
                 providerName,
                 specPathOrUrl: 'http://domain.com/swagger.json'
             });
         };
 
         it('should make an authenticated request to the root of the pact broker', async () => {
-            await invokeValidateWithPactBrokerAndAuth('http://pact-broker.com', 'provider-name', 'user:password');
+            await invokeValidateWithPactBrokerAndAuth('http://pact-broker.com', 'provider-name');
 
-            expect(mockHttpClient.get).toHaveBeenCalledWith('http://pact-broker.com', 'user:password');
+            expect(mockHttpClient.get).toHaveBeenCalledWith('http://pact-broker.com');
         });
 
         it('should make an authenticated request for the latest pact files for the provider', async () => {
@@ -438,10 +436,10 @@ describe('reading urls', () => {
             mockUrls['http://pact-broker.com/provider-name/pacts'] =
                 Promise.resolve(JSON.stringify(providerPactsBuilder.build()));
 
-            await invokeValidateWithPactBrokerAndAuth('http://pact-broker.com', 'provider-name', 'user:password');
+            await invokeValidateWithPactBrokerAndAuth('http://pact-broker.com', 'provider-name');
 
             expect(mockHttpClient.get)
-                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/pacts', 'user:password');
+                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/pacts');
         });
 
         it('should make a request for all the provider pact files', async () => {
@@ -459,12 +457,12 @@ describe('reading urls', () => {
             mockUrls['http://pact-broker.com/provider-name/consumer-2/pact'] =
                 Promise.resolve(JSON.stringify(pactBuilder.build()));
 
-            await invokeValidateWithPactBrokerAndAuth('http://pact-broker.com', 'provider-name', 'user:password');
+            await invokeValidateWithPactBrokerAndAuth('http://pact-broker.com', 'provider-name');
 
             expect(mockHttpClient.get)
-                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/consumer-1/pact', 'user:password');
+                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/consumer-1/pact');
             expect(mockHttpClient.get)
-                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/consumer-2/pact', 'user:password');
+                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/consumer-2/pact');
         });
     });
 
@@ -509,7 +507,7 @@ describe('reading urls', () => {
             await invokeValidateWithPactBrokerAndTag('http://pact-broker.com', 'provider-name', 'sample-tag');
 
             expect(mockHttpClient.get)
-                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/latest/sample-tag', undefined);
+                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/latest/sample-tag');
         });
 
         it('should pass but display a warning when there are no provider pact files for the given tag', async () => {
@@ -547,7 +545,7 @@ describe('reading urls', () => {
             await invokeValidateWithPactBrokerAndTag('http://pact-broker.com', 'provider-name', 'sample/tag');
 
             expect(mockHttpClient.get)
-                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/latest/sample%2Ftag', undefined);
+                .toHaveBeenCalledWith('http://pact-broker.com/provider-name/latest/sample%2Ftag');
         });
     });
 });

--- a/test/unit/support/swagger-mock-validator-loader.ts
+++ b/test/unit/support/swagger-mock-validator-loader.ts
@@ -32,7 +32,6 @@ export type MockUuidGeneratorResponses = string[];
 
 export interface SwaggerMockValidatorLoaderInvokeWithMocksOptions {
     analyticsUrl?: string;
-    auth?: string;
     fileSystem?: FileSystem;
     httpClient?: HttpClient;
     metadata?: Metadata;
@@ -111,7 +110,7 @@ export const swaggerMockValidatorLoader = {
         const mockMetadata = options.metadata || swaggerMockValidatorLoader.createMockMetadata({});
 
         const fileStore = new FileStore(mockFileSystem, mockHttpClient);
-        const pactBrokerClient = new PactBrokerClient(mockHttpClient, options.auth);
+        const pactBrokerClient = new PactBrokerClient(mockHttpClient);
         const pactBroker = new PactBroker(pactBrokerClient);
         const analytics = new Analytics(mockHttpClient, mockUuidGenerator, mockMetadata);
         const swaggerMockValidator = new SwaggerMockValidator(fileStore, pactBroker, analytics);


### PR DESCRIPTION
## Feature: Support retrieving OAS provider contracts from PactFlow

Allowing users to retrieve both Pact's (#44) and Provider contracts from PactFlow, we would provide a much quicker route to users self-diagnosing and replaying of the verification results locally

Assuming the user has the following env vars set

- `PACT_BROKER_TOKEN`

and have access to the consumer and provider contract url's that they wish to verify

Provider

- https://testdemo.pactflow.io/internal/contracts/bi-directional/provider/pact-provider-poc/version/64898db/consumer/pact-consumer-poc/version/9191e17/provider-contract 

Consumer

- https://testdemo.pactflow.io/pacts/provider/pact-provider-poc/consumer/pact-consumer-poc/version/9191e17

```
/bin/swagger-mock-validator.mjs https://testdemo.pactflow.io/internal/contracts/bi-directional/provider/pact-provider-poc/version/64898db/consumer/pact-consumer-poc/version/9191e17/provider-contract https://testdemo.pactflow.io/pacts/provider/pact-provider-poc/consumer/pact-consumer-poc/version/9191e17
```

## Notes

Leverages PactFlow internal url for BDCT

`internal/contracts/bi-directional`

Sample curl request

```console
curl -H "Authorization: Bearer $PACT_BROKER_TOKEN" https://testdemo.pactflow.io/internal/contracts/bi-directional/provider/pact-provider-poc/version/64898db/consumer/pact-consumer-poc/version/9191e17/provider-contract | jq .
```

relies on the following resource

`_embedded["providerContract"]["content"]`