### PR TITLE
fix: handle type:object in schema composition

### DIFF
--- a/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
+++ b/lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body.ts
@@ -7,7 +7,7 @@ import { ValidateOptions } from '../types';
 import { isTypesOfJson } from './content-negotiation';
 import { validateJson } from './validate-json';
 
-const transformSchema = (
+export const transformSchema = (
     schema: ParsedSpecJsonSchema,
     opts: Pick<ValidateOptions, 'additionalPropertiesInResponse' | 'requiredPropertiesInResponse'>
 ): ParsedSpecJsonSchema => {
@@ -18,7 +18,11 @@ const transformSchema = (
     if (!opts.additionalPropertiesInResponse) {
         traverseJsonSchema(modifiedSchema, (mutableSchema) => {
             if (
-                (typeof mutableSchema.additionalProperties === 'undefined' || mutableSchema.additionalProperties === true) &&
+                (typeof mutableSchema.additionalProperties === 'undefined' ||
+                    mutableSchema.additionalProperties === true) &&
+                !mutableSchema.oneOf &&
+                !mutableSchema.allOf &&
+                !mutableSchema.anyOf &&
                 mutableSchema.type &&
                 mutableSchema.type === 'object'
             ) {

--- a/test/unit/schema-transformation.spec.ts
+++ b/test/unit/schema-transformation.spec.ts
@@ -1,0 +1,48 @@
+import { transformSchema } from '../../lib/swagger-mock-validator/validate-spec-and-mock/validate-parsed-mock-response-body';
+
+// defaults
+const options = {
+    additionalPropertiesInResponse: false,
+    requiredPropertiesInResponse: false,
+};
+
+const transformedAdditionalProps = (schema) => transformSchema(schema, options).additionalProperties;
+const transformedRequired = (schema) => transformSchema(schema, options).required;
+
+describe('response transformation', () => {
+    // a provider must provide a superset of what the consumer asks for
+    // additionalProperties expected in pact response are disallowed
+    describe('additionalProperties', () => {
+        it('is prevented in objects', () => {
+            expect(transformedAdditionalProps({ type: 'object' })).toBeFalse();
+        });
+
+        it('is forced to be false', () => {
+            expect(transformedAdditionalProps({ type: 'object', additionalProperties: true })).toBeFalse();
+        });
+
+        it('allows schema composition', () => {
+            expect(transformedAdditionalProps({ type: 'object', oneOf: [] })).toBeUndefined();
+            expect(transformedAdditionalProps({ type: 'object', allOf: [] })).toBeUndefined();
+            expect(transformedAdditionalProps({ type: 'object', anyOf: [] })).toBeUndefined();
+        });
+    });
+
+    // a consumer may only use a subset of the provider *response*
+    // any field marked as required in OAS, should be considered optional for pact testing
+    describe('required properties', () => {
+        it('makes properties optional', () => {
+            expect(
+                transformedRequired({
+                    type: 'object',
+                    required: ['foo'],
+                    properties: {
+                        foo: {
+                            type: 'string',
+                        },
+                    },
+                })
+            ).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
Schemas are normally written like:
```
oneOf: [
  { $ref: "A" },
  { $ref: "B" },
]
```

But some schemas have a superfluous definition included:
```
type: "object",
oneOf: [
  { $ref: "A" },
  { $ref: "B" },
]
```

This breaks because we transform schemas based on `type: "object"` alone. This PR checks for the above scenario, so that we don't break when faced with such schemas.