### PR TITLE
feat: add option to publish verification result to pact broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ pact broker and the provider name should be passed using the --provider option. 
 automatically find the latest versions of the consumer pact file(s) uploaded to the broker for
 the specified provider name. The <swagger> argument should be the path or url to the swagger
 json file. Optionally, pass a --tag option alongside a --provider option to filter the retrieved
-pacts from the broker by Pact Broker version tags.
+pacts from the broker by Pact Broker version tags. Pass the --publish flag together with
+--providerApplicationVersion to publish the result to the pact broker.
 
 If the pact broker has basic auth enabled, pass a --user option with username and password joined by a colon
 (i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.
@@ -88,7 +89,11 @@ Options:
   -o, --outputDepth [integer]                     Specifies the number of times to recurse while formatting the output objects. This is useful in case of large complicated objects or schemas. (default: 4)
   -A, --additionalPropertiesInResponse [boolean]  allow additional properties in response bodies, default false
   -R, --requiredPropertiesInResponse [boolean]    allows required properties in response bodies, default false
+  --publish                                       Allows publication of verification result to pact broker, default false
+  --providerApplicationVersion [string]           Version of provider, used when publishing result to broker
+  --buildUrl [string]                             Url to build/pipeline, used when publishing result to broker
   -h, --help                                      display help for command
+
 ```
 
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -54,6 +54,9 @@ program
     'This is useful in case of large complicated objects or schemas.', parseInt, 4)
     .option('-A, --additionalPropertiesInResponse [boolean]', 'allow additional properties in response bodies, default false')
     .option('-R, --requiredPropertiesInResponse [boolean]', 'allows required properties in response bodies, default false')
+    .option('--publish', 'Allows publication of verification result to pact broker, default false')
+    .option('--providerApplicationVersion [string]', 'Version of provider, used when publishing result to broker')
+    .option('--buildUrl [string]', 'Url to build/pipeline, used when publishing result to broker')
     .description(
 `Confirms the swagger spec and mock are compatible with each other.
 
@@ -69,7 +72,8 @@ pact broker and the provider name should be passed using the --provider option. 
 automatically find the latest versions of the consumer pact file(s) uploaded to the broker for
 the specified provider name. The <swagger> argument should be the path or url to the swagger
 json file. Optionally, pass a --tag option alongside a --provider option to filter the retrieved
-pacts from the broker by Pact Broker version tags.
+pacts from the broker by Pact Broker version tags. Pass the --publish flag together with
+--providerApplicationVersion to publish the result to the pact broker.
 
 If the pact broker has basic auth enabled, pass a --user option with username and password joined by a colon
 (i.e. THE_USERNAME:THE_PASSWORD) to access the pact broker resources.`
@@ -85,7 +89,10 @@ If the pact broker has basic auth enabled, pass a --user option with username an
                 specPathOrUrl: swagger,
                 tag: options.tag,
                 additionalPropertiesInResponse: options.additionalPropertiesInResponse,
-                requiredPropertiesInResponse: options.requiredPropertiesInResponse
+                requiredPropertiesInResponse: options.requiredPropertiesInResponse,
+                providerApplicationVersion: options.providerApplicationVersion,
+                buildUrl: options.buildUrl,
+                publish: options.publish
             });
 
             displaySummary(result, options.outputDepth);

--- a/lib/swagger-mock-validator.ts
+++ b/lib/swagger-mock-validator.ts
@@ -53,7 +53,8 @@ const parseUserOptions = (
       ? false // default to false - existing behaviour
       : userOptions.requiredPropertiesInResponse === 'true'
       ? true
-      : false
+      : false,
+  publish: typeof userOptions.publish !== 'undefined'
 });
 
 const combineValidationResults = (
@@ -228,6 +229,10 @@ export class SwaggerMockValidator {
         result.parsedMock,
         result.validationOutcome
       );
+
+      if (options.publish) {
+        await this.pactBroker.publishVerificationResult(options, result.parsedMock, result.validationOutcome);
+      }
     }
 
     return result.validationOutcome;

--- a/lib/swagger-mock-validator/clients/http-client.ts
+++ b/lib/swagger-mock-validator/clients/http-client.ts
@@ -13,8 +13,11 @@ export class HttpClient {
         return response.data;
     }
 
-    public async post(url: string, body: any): Promise<void> {
+    public async post(url: string, body: any, auth?: string): Promise<void> {
         await axios.post(url, body, {
+            headers: {
+                ...(auth ? {authorization: 'Basic ' + Buffer.from(auth).toString('base64')} : {})
+            },
             timeout: 5000,
             validateStatus: (status) => status >= 200 && status <= 299
         });

--- a/lib/swagger-mock-validator/clients/pact-broker-client.ts
+++ b/lib/swagger-mock-validator/clients/pact-broker-client.ts
@@ -27,4 +27,14 @@ export class PactBrokerClient {
             );
         }
     }
+
+    public async post(url: string, body: object): Promise<void> {
+        try {
+            await this.httpClient.post(url, body, this.auth);
+        } catch (error) {
+            throw new SwaggerMockValidatorErrorImpl(
+                'SWAGGER_MOCK_VALIDATOR_READ_ERROR', `Unable to post "${url}"`, error
+            );
+        }
+    }
 }

--- a/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact-parser.ts
@@ -214,6 +214,7 @@ export const pactParser = {
             interactions: pactJson.interactions.filter(filterUnsupportedTypes).map(parseInteraction),
             pathOrUrl: mockPathOrUrl,
             provider: pactJson.provider.name,
+            verificationUrl: pactJson._links?.['pb:publish-verification-results']?.href
         };
     },
 };

--- a/lib/swagger-mock-validator/mock-parser/pact/pact.d.ts
+++ b/lib/swagger-mock-validator/mock-parser/pact/pact.d.ts
@@ -13,6 +13,11 @@ export interface Pact {
     metadata?: PactMetadata;
     metaData?: PactMetadata;
     provider: { name: string };
+    _links?: {
+        'pb:publish-verification-results'?: {
+            href: string;
+        }
+    };
 }
 
 export interface PactInteraction {

--- a/lib/swagger-mock-validator/mock-parser/parsed-mock.d.ts
+++ b/lib/swagger-mock-validator/mock-parser/parsed-mock.d.ts
@@ -3,6 +3,7 @@ export interface ParsedMock {
     interactions: ParsedMockInteraction[];
     pathOrUrl: string;
     provider: string;
+    verificationUrl?: string;
 }
 
 export interface ParsedMockInteraction extends ParsedMockValue<any> {

--- a/lib/swagger-mock-validator/pact-broker.ts
+++ b/lib/swagger-mock-validator/pact-broker.ts
@@ -7,8 +7,11 @@ import {
     PactBrokerRootResponse,
     PactBrokerUserOptions,
     PactBrokerUserOptionsWithTag,
+    ParsedSwaggerMockValidatorOptions,
     SerializedMock
 } from './types';
+import {ValidationOutcome} from '../api-types';
+import {ParsedMock} from './mock-parser/parsed-mock';
 
 export class PactBroker {
     private static getProviderTemplateUrl(pactBrokerRootResponse: PactBrokerRootResponse, template: string): string {
@@ -23,6 +26,25 @@ export class PactBroker {
         const pactUrls = await this.getPactUrls(providerPactsUrl);
 
         return this.getPacts(pactUrls);
+    }
+
+    public async publishVerificationResult(
+        {providerApplicationVersion, buildUrl}: ParsedSwaggerMockValidatorOptions,
+        {verificationUrl}: ParsedMock,
+        {success}: ValidationOutcome
+    ): Promise<void> {
+        if (!verificationUrl) {
+            throw new SwaggerMockValidatorErrorImpl(
+                'SWAGGER_MOCK_VALIDATOR_READ_ERROR',
+                `No verification publication url available in pact`
+            );
+        }
+
+        return this.pactBrokerClient.post(verificationUrl, {
+            success,
+            providerApplicationVersion,
+            buildUrl,
+        });
     }
 
     private async getUrlForProviderPacts(options: PactBrokerUserOptions): Promise<string> {

--- a/lib/swagger-mock-validator/types.d.ts
+++ b/lib/swagger-mock-validator/types.d.ts
@@ -33,6 +33,9 @@ export interface SwaggerMockValidatorUserOptions {
     tag?: string;
     additionalPropertiesInResponse?: string;
     requiredPropertiesInResponse?: string;
+    providerApplicationVersion?: string;
+    buildUrl?: string;
+    publish?: string;
 }
 
 export interface PactBrokerUserOptions {
@@ -76,6 +79,9 @@ interface ParsedSwaggerMockValidatorOptions {
     tag?: string;
     additionalPropertiesInResponse: boolean;
     requiredPropertiesInResponse: boolean;
+    providerApplicationVersion?: string;
+    buildUrl?: string;
+    publish: boolean;
 }
 
 export type MockSource = 'pactBroker' | 'path' | 'url';

--- a/test/e2e/fixtures/pact-working-consumer.json
+++ b/test/e2e/fixtures/pact-working-consumer.json
@@ -326,5 +326,10 @@
     }],
     "metadata": {
         "pactSpecificationVersion": "1.0.0"
+    },
+    "_links": {
+        "pb:publish-verification-results": {
+            "href": "http://localhost:8000/publish"
+        }
     }
 }


### PR DESCRIPTION
Sorry for not opening an issue with discussion first, the company I work for needed to know if this was a viable option so we decided to spend an afternoon on it before exploring other avenues.

This is basically the bare minimum to be able to publish the results to the pact broker according to: https://docs.pact.io/pact_broker/advanced_topics/api_docs/publish_verification_result

I'm open to implement any changes you see fit.