### PR TITLE
feat: fetch latest pacts for provider by branch

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -47,6 +47,7 @@ program
     .arguments('<swagger> <mock>')
     .option('-p, --provider [string]', 'The name of the provider in the pact broker')
     .option('-t, --tag [string]', 'The tag to filter pacts retrieved from the pact broker')
+    .option('-b, --branch [string]', 'The branch to filter pacts retrieved from the pact broker')
     .option('-u, --user [USERNAME:PASSWORD]', 'The basic auth username and password to access the pact broker')
     .option('-a, --analyticsUrl [string]', 'The url to send analytics events to as a http post')
     .option('-o, --outputDepth [integer]', 'Specifies the number of times to recurse ' +
@@ -84,6 +85,7 @@ If the pact broker has basic auth enabled, pass a --user option with username an
                 providerName: options.provider,
                 specPathOrUrl: swagger,
                 tag: options.tag,
+                branch: options.branch,
                 additionalPropertiesInResponse: options.additionalPropertiesInResponse,
                 requiredPropertiesInResponse: options.requiredPropertiesInResponse
             });

--- a/lib/swagger-mock-validator.ts
+++ b/lib/swagger-mock-validator.ts
@@ -160,7 +160,8 @@ export class SwaggerMockValidator {
       ? this.pactBroker.loadPacts({
           pactBrokerUrl: options.mockPathOrUrl,
           providerName: options.providerName,
-          tag: options.tag
+          tag: options.tag,
+          branch: options.branch
         })
       : this.getPactFromFileOrUrl(options.mockPathOrUrl);
 

--- a/lib/swagger-mock-validator/types.d.ts
+++ b/lib/swagger-mock-validator/types.d.ts
@@ -31,6 +31,7 @@ export interface SwaggerMockValidatorUserOptions {
     providerName?: string;
     specPathOrUrl: string;
     tag?: string;
+    branch?: string;
     additionalPropertiesInResponse?: string;
     requiredPropertiesInResponse?: string;
 }
@@ -39,10 +40,14 @@ export interface PactBrokerUserOptions {
     pactBrokerUrl: string;
     providerName: string;
     tag?: string;
+    branch?: string;
 }
 
 export type PactBrokerUserOptionsWithTag = PactBrokerUserOptions & {
     tag: string;
+};
+export type PactBrokerUserOptionsWithBranch = PactBrokerUserOptions & {
+    branch: string;
 };
 
 export type AutoDetectFormat = 'auto-detect';
@@ -74,6 +79,7 @@ interface ParsedSwaggerMockValidatorOptions {
     specPathOrUrl: string;
     specSource: SpecSource;
     tag?: string;
+    branch?: string;
     additionalPropertiesInResponse: boolean;
     requiredPropertiesInResponse: boolean;
 }


### PR DESCRIPTION
Support fetching latest pacts for provider, with specified consumer branch (addition from existing behaviour of supporting retrieval via tags)

uses latest-provider-pacts-with-branch

relies on https://github.com/pact-foundation/pact_broker/pull/728