### PR TITLE
fix(security-requirements): handle unexpected securitySchemes structure

### DIFF
--- a/lib/swagger-mock-validator/spec-parser/openapi3/openapi3-parser/parse-security-requirements.ts
+++ b/lib/swagger-mock-validator/spec-parser/openapi3/openapi3-parser/parse-security-requirements.ts
@@ -100,7 +100,13 @@ const toRequirementDefinition = (
     name: string,
     securitySchemes: DereferencedSecuritySchemes,
     securityRequirement: SecurityRequirement
-): RequirementDefinition => ({name, scheme: securitySchemes[name], value: securityRequirement[name]});
+): RequirementDefinition => {
+  const scheme = securitySchemes[name];
+  if (typeof scheme === 'undefined') {
+    throw new Error(`"${name}" was not found in "securitySchemes"`);
+  }
+  return { name, scheme, value: securityRequirement[name], };
+}
 
 const parseSecurityRequirementGroup = (
     securityRequirement: SecurityRequirement,


### PR DESCRIPTION
When the provider-side OpenAPI schema has unexpected structure in `"security"` and `"securitySchemes"`, PactFlow's `can-i-deploy` results in a mysterious error.

![Screenshot 2025-01-27 at 15 09 58](https://github.com/user-attachments/assets/ade91ca8-5b7e-49ff-a954-6c8d33cf3fea)

This is because of access to a property of an object with index signature without proper validation. (That's why [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) is important.)
This eventually results in trying to read `.type` of `undefined` at https://github.com/pactflow/swagger-mock-validator/blob/3a2dab49f3567234b1f802bb57d06166d1019a09/lib/swagger-mock-validator/spec-parser/openapi3/openapi3-parser/parse-security-requirements.ts#L57

This fix aims a quick patch to at least improve the error message. There might be a more proper fix to emit a more useful error messages when OpenAPI schema has unexpected structure.